### PR TITLE
feat: add AI Diagnostic Result tab with SSE streaming

### DIFF
--- a/diagnostic_api/alembic/versions/e6f7a8b9c0d1_add_ai_diagnosis.py
+++ b/diagnostic_api/alembic/versions/e6f7a8b9c0d1_add_ai_diagnosis.py
@@ -1,0 +1,48 @@
+"""add diagnosis_text column and obd_ai_diagnosis_feedback table
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-02-15 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'e6f7a8b9c0d1'
+down_revision: Union[str, None] = 'd5e6f7a8b9c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add diagnosis_text column to obd_analysis_sessions
+    op.add_column(
+        'obd_analysis_sessions',
+        sa.Column('diagnosis_text', sa.Text(), nullable=True),
+    )
+
+    # Create obd_ai_diagnosis_feedback table
+    op.create_table(
+        'obd_ai_diagnosis_feedback',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('session_id', postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey('obd_analysis_sessions.id'), nullable=False),
+        sa.Column('rating', sa.Integer(), nullable=False),
+        sa.Column('is_helpful', sa.Boolean(), nullable=False),
+        sa.Column('comments', sa.Text(), nullable=True),
+        sa.Column('corrected_diagnosis', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+    op.create_index('ix_obd_ai_diagnosis_feedback_session_id',
+                    'obd_ai_diagnosis_feedback', ['session_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_obd_ai_diagnosis_feedback_session_id',
+                  table_name='obd_ai_diagnosis_feedback')
+    op.drop_table('obd_ai_diagnosis_feedback')
+    op.drop_column('obd_analysis_sessions', 'diagnosis_text')

--- a/diagnostic_api/app/api/v2/endpoints/obd_analysis.py
+++ b/diagnostic_api/app/api/v2/endpoints/obd_analysis.py
@@ -2,26 +2,32 @@
 
 POST /v2/obd/analyze                    — accepts raw TSV body, runs pipeline, caches result
 GET  /v2/obd/{session_id}              — cache-first, DB fallback retrieval
-POST /v2/obd/{session_id}/feedback/summary  — expert feedback on summary view
-POST /v2/obd/{session_id}/feedback/detailed — expert feedback on detailed view
-POST /v2/obd/{session_id}/feedback/rag      — expert feedback on RAG view
+POST /v2/obd/{session_id}/diagnose     — generate AI diagnosis (Dify workflow style)
+POST /v2/obd/{session_id}/feedback/summary       — expert feedback on summary view
+POST /v2/obd/{session_id}/feedback/detailed      — expert feedback on detailed view
+POST /v2/obd/{session_id}/feedback/rag           — expert feedback on RAG view
+POST /v2/obd/{session_id}/feedback/ai_diagnosis  — expert feedback on AI diagnosis view
 """
 
 from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import os
 import tempfile
 import uuid
-from typing import Literal, Type, Union
+from dataclasses import replace
+from typing import Literal, NamedTuple, Optional, Type, Union
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
+from app.db.session import SessionLocal
 from app.api.v2.endpoints.log_summary import _run_pipeline, _MAX_FILE_SIZE
 from app.api.v2.schemas import (
     LogSummaryV2,
@@ -29,13 +35,29 @@ from app.api.v2.schemas import (
     OBDFeedbackRequest,
 )
 from app.cache import CachedSession, obd_cache
-from app.models_db import OBDDetailedFeedback, OBDRAGFeedback, OBDSummaryFeedback, OBDAnalysisSession
+from app.expert.client import ExpertLLMClient
+from app.models_db import (
+    OBDAIDiagnosisFeedback,
+    OBDDetailedFeedback,
+    OBDRAGFeedback,
+    OBDSummaryFeedback,
+    OBDAnalysisSession,
+)
+from app.rag.retrieve import retrieve_context
 from obd_agent.summary_formatter import format_summary_for_dify
 
-FeedbackModel = Type[Union[OBDSummaryFeedback, OBDDetailedFeedback, OBDRAGFeedback]]
-FeedbackType = Literal["summary", "detailed", "rag"]
+FeedbackModel = Type[Union[OBDSummaryFeedback, OBDDetailedFeedback, OBDRAGFeedback, OBDAIDiagnosisFeedback]]
+FeedbackType = Literal["summary", "detailed", "rag", "ai_diagnosis"]
 
 _MAX_FEEDBACK_PER_SESSION: int = 10
+_MAX_DIAGNOSIS_LENGTH: int = 50_000
+_expert_client = ExpertLLMClient()
+
+
+class SessionData(NamedTuple):
+    parsed_summary: Optional[dict]
+    diagnosis_text: Optional[str]
+    source: str
 
 logger = structlog.get_logger()
 
@@ -166,6 +188,7 @@ async def get_obd_session(
             result=result,
             error_message=cached.error_message,
             parsed_summary=cached.parsed_summary_payload,
+            diagnosis_text=cached.diagnosis_text,
         )
 
     # 2. DB fallback (post-feedback sessions)
@@ -187,6 +210,7 @@ async def get_obd_session(
         result=result,
         error_message=db_session.error_message,
         parsed_summary=db_session.parsed_summary_payload,
+        diagnosis_text=db_session.diagnosis_text,
     )
 
 
@@ -225,6 +249,7 @@ def _ensure_session_in_db(
         result_payload=cached.result_payload,
         parsed_summary_payload=cached.parsed_summary_payload,
         error_message=cached.error_message,
+        diagnosis_text=cached.diagnosis_text,
         created_at=cached.created_at,
     )
     db.add(db_session)
@@ -360,4 +385,173 @@ async def submit_rag_feedback(
 ) -> dict:
     return await _submit_feedback(
         session_id, feedback, db, OBDRAGFeedback, "rag",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AI Diagnosis (Dify workflow replication)
+# ---------------------------------------------------------------------------
+
+
+def _get_session_data(
+    session_id: uuid.UUID,
+    db: Session,
+) -> SessionData:
+    """Return (parsed_summary, diagnosis_text, source) from cache or DB."""
+    sid = str(session_id)
+
+    cached = obd_cache.get(sid)
+    if cached is not None:
+        return SessionData(cached.parsed_summary_payload, cached.diagnosis_text, "cache")
+
+    db_session = (
+        db.query(OBDAnalysisSession)
+        .filter(OBDAnalysisSession.id == session_id)
+        .first()
+    )
+    if db_session is None:
+        raise HTTPException(status_code=404, detail="OBD analysis session not found")
+
+    return SessionData(db_session.parsed_summary_payload, db_session.diagnosis_text, "db")
+
+
+def _store_diagnosis_text(
+    session_id: uuid.UUID,
+    diagnosis_text: str,
+) -> None:
+    """Persist diagnosis_text to cache and/or DB.
+
+    Uses its own DB session so it is safe to call from a streaming
+    generator (where the request-scoped ``Depends(get_db)`` session
+    may already be closed).
+    """
+    sid = str(session_id)
+    text = diagnosis_text[:_MAX_DIAGNOSIS_LENGTH]
+
+    # Update cache (frozen dataclass → replace)
+    cached = obd_cache.get(sid)
+    if cached is not None:
+        updated = replace(cached, diagnosis_text=text)
+        obd_cache.put(updated)
+
+    # Update DB if session exists there — use a dedicated session
+    db = SessionLocal()
+    try:
+        db_session = (
+            db.query(OBDAnalysisSession)
+            .filter(OBDAnalysisSession.id == session_id)
+            .first()
+        )
+        if db_session is not None:
+            db_session.diagnosis_text = text
+            db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+@router.post(
+    "/{session_id}/diagnose",
+    summary="Generate AI diagnosis (SSE stream)",
+)
+async def generate_diagnosis(
+    session_id: uuid.UUID,
+    db: Session = Depends(get_db),
+) -> StreamingResponse:
+    """Run the Dify-style AI diagnosis workflow with SSE streaming.
+
+    SSE event types:
+      - ``token``  : incremental text chunk from the LLM
+      - ``done``   : final event; ``data`` contains the full diagnosis text
+      - ``error``  : generation failed; ``data`` contains error message
+      - ``cached`` : diagnosis was already generated; ``data`` contains full text
+
+    If the diagnosis was previously generated, a single ``cached`` event is
+    sent and the stream closes immediately.
+    """
+    # --- pre-flight checks (run before entering the stream generator) ---
+    parsed_summary, existing_diagnosis, source = _get_session_data(session_id, db)
+
+    if existing_diagnosis:
+        async def _cached_stream():
+            yield _sse_event("cached", existing_diagnosis)
+
+        return StreamingResponse(
+            _cached_stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    if not parsed_summary:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Session has no parsed summary — cannot generate diagnosis.",
+        )
+
+    # RAG retrieval (before stream starts so errors surface as HTTP errors)
+    rag_query = parsed_summary.get("rag_query", "")
+    context_str = ""
+    if rag_query:
+        try:
+            results = await retrieve_context(rag_query, top_k=3)
+            context_str = "\n\n".join(
+                f"[{r.source_type} - {r.doc_id} - {r.section_title}]\n{r.text}"
+                for r in results
+            )
+        except Exception as exc:
+            logger.warning("diagnosis_rag_retrieval_failed", error=str(exc))
+
+    # --- streaming generator ---
+    async def _stream():
+        # Send an initial padding comment to force browser buffer flush.
+        # Browsers may buffer small fetch ReadableStream chunks; a ~2 KB
+        # initial payload ensures the first real SSE events are delivered
+        # immediately.
+        yield ": " + " " * 2048 + "\n\n"
+        yield _sse_event("status", "Retrieving context and initializing LLM...")
+
+        full_text_parts: list[str] = []
+        try:
+            async for token in _expert_client.generate_obd_diagnosis_stream(
+                parsed_summary, context_str
+            ):
+                full_text_parts.append(token)
+                yield _sse_event("token", token)
+
+            full_text = "".join(full_text_parts)
+            _store_diagnosis_text(session_id, full_text)
+            logger.info("obd_diagnosis_generated", session_id=str(session_id))
+            yield _sse_event("done", full_text)
+
+        except Exception as exc:
+            logger.error("obd_diagnosis_stream_error", error=str(exc))
+            yield _sse_event("error", str(exc))
+
+    return StreamingResponse(
+        _stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+def _sse_event(event: str, data: str) -> str:
+    """Format a single SSE event frame."""
+    escaped = json.dumps(data)
+    return f"event: {event}\ndata: {escaped}\n\n"
+
+
+@router.post(
+    "/{session_id}/feedback/ai_diagnosis",
+    status_code=status.HTTP_201_CREATED,
+    summary="Submit expert feedback for the AI diagnosis view",
+)
+async def submit_ai_diagnosis_feedback(
+    session_id: uuid.UUID,
+    feedback: OBDFeedbackRequest,
+    db: Session = Depends(get_db),
+) -> dict:
+    return await _submit_feedback(
+        session_id, feedback, db, OBDAIDiagnosisFeedback, "ai_diagnosis",
     )

--- a/diagnostic_api/app/api/v2/schemas.py
+++ b/diagnostic_api/app/api/v2/schemas.py
@@ -138,6 +138,7 @@ class OBDAnalysisResponse(BaseModel):
     result: Optional[LogSummaryV2] = None
     error_message: Optional[str] = None
     parsed_summary: Optional[dict] = None
+    diagnosis_text: Optional[str] = None
 
 
 class OBDSessionSummary(BaseModel):

--- a/diagnostic_api/app/cache/obd_session_cache.py
+++ b/diagnostic_api/app/cache/obd_session_cache.py
@@ -30,6 +30,7 @@ class CachedSession:
     result_payload: Optional[dict]
     parsed_summary_payload: Optional[dict]
     error_message: Optional[str]
+    diagnosis_text: Optional[str] = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/diagnostic_api/app/expert/prompts.py
+++ b/diagnostic_api/app/expert/prompts.py
@@ -49,3 +49,56 @@ Diagnostic Instruction:
 Analyze the above information. Determine the most likely root causes.
 Return the result in the strict JSON format specified in the system prompt.
 """
+
+
+# ---------------------------------------------------------------------------
+# OBD Diagnosis prompts (free-form markdown, replicating Dify workflow)
+# ---------------------------------------------------------------------------
+
+OBD_DIAGNOSIS_SYSTEM_PROMPT = """\
+You are an expert automotive diagnostic technician with deep knowledge \
+of OBD-II protocols, engine management systems, and vehicle diagnostics.
+
+Rules:
+1. Reference exact PID names, values, and units from the data provided.
+2. Cite retrieved context when it supports your analysis.
+3. Cross-correlate multiple PIDs to identify related issues.
+4. Distinguish between confirmed faults and suspected faults.
+5. Rate severity: CRITICAL, MODERATE, or LOW.
+6. Structure your response as:
+   - Summary (1-2 sentences)
+   - Findings (bullet points per issue)
+   - Root Cause Analysis
+   - Recommendations (actionable steps)
+   - Limitations (what additional data would help)"""
+
+OBD_DIAGNOSIS_USER_TEMPLATE = """\
+Diagnose the following vehicle based on its OBD-II log data.
+
+**Vehicle ID:** {vehicle_id}
+
+**Time Range:** {time_range}
+
+**DTC Codes:** {dtc_codes}
+
+**PID Statistics:**
+
+{pid_summary}
+
+**Anomaly Events (with severity, context, and scores):**
+
+{anomaly_events}
+
+**Diagnostic Clues (rule-based, with evidence):**
+
+{diagnostic_clues}
+
+---
+
+**Retrieved Technical Context:**
+
+{context}
+
+---
+
+Provide your expert diagnosis following the required structure."""

--- a/diagnostic_api/app/models_db.py
+++ b/diagnostic_api/app/models_db.py
@@ -126,6 +126,9 @@ class OBDAnalysisSession(Base):
 
     error_message = Column(Text, nullable=True)
 
+    # AI diagnosis (free-form markdown from LLM)
+    diagnosis_text = Column(Text, nullable=True)
+
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
 
@@ -133,6 +136,7 @@ class OBDAnalysisSession(Base):
     summary_feedback = relationship("OBDSummaryFeedback", back_populates="session", uselist=True)
     detailed_feedback = relationship("OBDDetailedFeedback", back_populates="session", uselist=True)
     rag_feedback = relationship("OBDRAGFeedback", back_populates="session", uselist=True)
+    ai_diagnosis_feedback = relationship("OBDAIDiagnosisFeedback", back_populates="session", uselist=True)
 
 
 class _OBDFeedbackMixin:
@@ -184,3 +188,11 @@ class OBDRAGFeedback(_OBDFeedbackMixin, Base):
     __tablename__ = "obd_rag_feedback"
 
     session = relationship("OBDAnalysisSession", back_populates="rag_feedback")
+
+
+class OBDAIDiagnosisFeedback(_OBDFeedbackMixin, Base):
+    """Expert feedback on OBD AI diagnosis view."""
+
+    __tablename__ = "obd_ai_diagnosis_feedback"
+
+    session = relationship("OBDAnalysisSession", back_populates="ai_diagnosis_feedback")

--- a/obd-ui/src/app/analysis/[sessionId]/page.tsx
+++ b/obd-ui/src/app/analysis/[sessionId]/page.tsx
@@ -56,7 +56,7 @@ export default function AnalysisPage() {
     );
   }
 
-  return <AnalysisLayout sessionId={sessionId} data={data.result} parsedSummary={data.parsed_summary} />;
+  return <AnalysisLayout sessionId={sessionId} data={data.result} parsedSummary={data.parsed_summary} diagnosisText={data.diagnosis_text} />;
 }
 
 function AnalysisLoadingSkeleton() {

--- a/obd-ui/src/components/AIDiagnosisView.tsx
+++ b/obd-ui/src/components/AIDiagnosisView.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { streamDiagnosis } from "@/lib/api";
+
+interface AIDiagnosisViewProps {
+  sessionId: string;
+  initialDiagnosisText: string | null;
+}
+
+export function AIDiagnosisView({ sessionId, initialDiagnosisText }: AIDiagnosisViewProps) {
+  const [diagnosisText, setDiagnosisText] = useState<string>(initialDiagnosisText ?? "");
+  const [streaming, setStreaming] = useState(false);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [done, setDone] = useState(!!initialDiagnosisText);
+  const [error, setError] = useState<string | null>(null);
+  const textRef = useRef("");
+
+  const handleGenerate = useCallback(async () => {
+    setStreaming(true);
+    setError(null);
+    setStatusMsg("Connecting...");
+    setDiagnosisText("");
+    textRef.current = "";
+
+    try {
+      await streamDiagnosis(
+        sessionId,
+        (token) => {
+          setStatusMsg(null);
+          textRef.current += token;
+          setDiagnosisText(textRef.current);
+        },
+        (_fullText) => {
+          setStatusMsg(null);
+          setDone(true);
+          setStreaming(false);
+        },
+        (err) => {
+          setStatusMsg(null);
+          setError(err);
+          setStreaming(false);
+        },
+        (status) => {
+          setStatusMsg(status);
+        },
+      );
+      // Stream ended (connection closed)
+      setStreaming(false);
+      if (textRef.current) setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate diagnosis");
+      setStreaming(false);
+      setStatusMsg(null);
+    }
+  }, [sessionId]);
+
+  // Not started yet — show generate button
+  if (!streaming && !diagnosisText) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">AI Diagnostic Result</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Generate an AI-powered diagnostic report using the parsed OBD data and retrieved technical context.
+            This may take 1-2 minutes on first generation.
+          </p>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <Button onClick={handleGenerate} className="w-full">
+            Generate AI Diagnosis
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Streaming or completed — show progressive text
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">AI Diagnostic Result</CardTitle>
+          {streaming && (
+            <span className="text-xs text-muted-foreground animate-pulse">
+              Generating...
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Status message while waiting for LLM first token */}
+        {streaming && statusMsg && !diagnosisText && (
+          <div className="flex items-center gap-3 py-8 justify-center text-sm text-muted-foreground">
+            <svg className="h-5 w-5 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            <span>{statusMsg}</span>
+          </div>
+        )}
+
+        {diagnosisText && (
+          <pre className="whitespace-pre-wrap text-sm leading-relaxed font-sans">
+            {diagnosisText}
+            {streaming && <span className="inline-block w-2 h-4 bg-foreground animate-pulse align-text-bottom" />}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/obd-ui/src/components/AnalysisLayout.tsx
+++ b/obd-ui/src/components/AnalysisLayout.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SummaryView } from "@/components/SummaryView";
 import { DetailedView } from "@/components/DetailedView";
 import { RAGView } from "@/components/RAGView";
+import { AIDiagnosisView } from "@/components/AIDiagnosisView";
 import { FeedbackForm } from "@/components/FeedbackForm";
 import { formatDuration } from "@/lib/utils";
 
@@ -13,9 +14,10 @@ interface AnalysisLayoutProps {
   sessionId: string;
   data: LogSummaryV2;
   parsedSummary: ParsedSummary | null;
+  diagnosisText: string | null;
 }
 
-export function AnalysisLayout({ sessionId, data, parsedSummary }: AnalysisLayoutProps) {
+export function AnalysisLayout({ sessionId, data, parsedSummary, diagnosisText }: AnalysisLayoutProps) {
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -50,6 +52,7 @@ export function AnalysisLayout({ sessionId, data, parsedSummary }: AnalysisLayou
           <TabsTrigger value="summary">Summary</TabsTrigger>
           <TabsTrigger value="detailed">Detailed</TabsTrigger>
           <TabsTrigger value="rag">RAG</TabsTrigger>
+          <TabsTrigger value="ai_diagnosis">AI Diagnostic Result</TabsTrigger>
         </TabsList>
 
         <TabsContent value="summary" className="space-y-6">
@@ -65,6 +68,11 @@ export function AnalysisLayout({ sessionId, data, parsedSummary }: AnalysisLayou
         <TabsContent value="rag" className="space-y-6">
           <RAGView ragQuery={parsedSummary?.rag_query ?? ""} />
           <FeedbackForm sessionId={sessionId} feedbackTab="rag" />
+        </TabsContent>
+
+        <TabsContent value="ai_diagnosis" className="space-y-6">
+          <AIDiagnosisView sessionId={sessionId} initialDiagnosisText={diagnosisText} />
+          <FeedbackForm sessionId={sessionId} feedbackTab="ai_diagnosis" />
         </TabsContent>
       </Tabs>
     </div>

--- a/obd-ui/src/components/FeedbackForm.tsx
+++ b/obd-ui/src/components/FeedbackForm.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 
 interface FeedbackFormProps {
   sessionId: string;
-  feedbackTab: "summary" | "detailed" | "rag";
+  feedbackTab: "summary" | "detailed" | "rag" | "ai_diagnosis";
 }
 
 export function FeedbackForm({ sessionId, feedbackTab }: FeedbackFormProps) {
@@ -73,7 +73,7 @@ export function FeedbackForm({ sessionId, feedbackTab }: FeedbackFormProps) {
     <Card>
       <CardHeader>
         <CardTitle className="text-lg">
-          Expert Feedback — {feedbackTab === "summary" ? "Summary" : feedbackTab === "detailed" ? "Detailed" : "RAG"} View
+          Expert Feedback — {feedbackTab === "summary" ? "Summary" : feedbackTab === "detailed" ? "Detailed" : feedbackTab === "rag" ? "RAG" : "AI Diagnosis"} View
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">

--- a/obd-ui/src/lib/api.ts
+++ b/obd-ui/src/lib/api.ts
@@ -40,10 +40,99 @@ export async function retrieveRAG(
   return res.json();
 }
 
+/**
+ * Stream AI diagnosis via SSE.
+ *
+ * @param onToken   Called for each incremental text chunk.
+ * @param onDone    Called once with the full diagnosis text when generation completes.
+ * @param onError   Called if the stream encounters an error.
+ * @param onStatus  Called with status messages (e.g. "Initializing LLM...").
+ */
+export async function streamDiagnosis(
+  sessionId: string,
+  onToken: (token: string) => void,
+  onDone: (fullText: string) => void,
+  onError: (error: string) => void,
+  onStatus?: (message: string) => void,
+): Promise<void> {
+  const res = await fetch(`${API_URL}/v2/obd/${sessionId}/diagnose`, {
+    method: "POST",
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(detail.detail || `HTTP ${res.status}`);
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error("No response body");
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    // Parse complete SSE frames from the buffer
+    const frames = buffer.split("\n\n");
+    // Last element may be incomplete — keep it in buffer
+    buffer = frames.pop() ?? "";
+
+    for (const frame of frames) {
+      if (!frame.trim()) continue;
+
+      // Skip SSE comments (lines starting with ":")
+      const lines = frame.split("\n").filter((l) => !l.startsWith(":"));
+      if (lines.length === 0) continue;
+
+      let event = "";
+      let data = "";
+
+      for (const line of lines) {
+        if (line.startsWith("event: ")) {
+          event = line.slice(7);
+        } else if (line.startsWith("data: ")) {
+          data = line.slice(6);
+        }
+      }
+
+      if (!data) continue;
+
+      // data is JSON-encoded string
+      let parsed: string;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        parsed = data;
+      }
+
+      switch (event) {
+        case "token":
+          onToken(parsed);
+          break;
+        case "cached":
+        case "done":
+          onDone(parsed);
+          break;
+        case "error":
+          onError(parsed);
+          break;
+        case "status":
+          onStatus?.(parsed);
+          break;
+      }
+    }
+  }
+}
+
 export async function submitFeedback(
   sessionId: string,
   feedback: OBDFeedbackRequest,
-  tab: "summary" | "detailed" | "rag",
+  tab: "summary" | "detailed" | "rag" | "ai_diagnosis",
 ): Promise<FeedbackResponse> {
   const res = await fetch(`${API_URL}/v2/obd/${sessionId}/feedback/${tab}`, {
     method: "POST",

--- a/obd-ui/src/lib/types.ts
+++ b/obd-ui/src/lib/types.ts
@@ -95,6 +95,7 @@ export interface OBDAnalysisResponse {
   result: LogSummaryV2 | null;
   error_message: string | null;
   parsed_summary: ParsedSummary | null;
+  diagnosis_text: string | null;
 }
 
 export interface OBDFeedbackRequest {


### PR DESCRIPTION
## Summary

- Add 4th "AI Diagnostic Result" tab replicating the Dify diagnostic workflow (parsed OBD summary + RAG context -> Ollama llama3:8b LLM)
- SSE streaming for progressive token-by-token rendering with status messages and blinking cursor
- Full-stack: backend endpoints, DB migration, caching, frontend component, and expert feedback support

## Changes

**Backend (7 files):**
- `expert/prompts.py` — Dify-style system/user prompts for free-form markdown diagnosis
- `expert/client.py` — `generate_obd_diagnosis_stream()` method using OpenAI streaming API
- `cache/obd_session_cache.py` — `diagnosis_text` field on `CachedSession`
- `models_db.py` — `diagnosis_text` column + `OBDAIDiagnosisFeedback` model
- `schemas.py` — `diagnosis_text` on `OBDAnalysisResponse`
- `endpoints/obd_analysis.py` — SSE `/diagnose` endpoint + AI diagnosis feedback endpoint
- `alembic/versions/e6f7a8b9c0d1_add_ai_diagnosis.py` — migration

**Frontend (6 files):**
- `AIDiagnosisView.tsx` — new component with generate button, streaming display, status spinner
- `AnalysisLayout.tsx` — 4th tab wired up
- `api.ts` — `streamDiagnosis()` SSE client via fetch ReadableStream
- `types.ts` — `diagnosis_text` field
- `FeedbackForm.tsx` — extended for `ai_diagnosis` tab
- `page.tsx` — passes `diagnosisText` prop

## Key design decisions

- **SSE over WebSocket**: one-directional stream, simpler, works with POST
- **2KB padding flush**: forces browser to deliver first SSE events immediately
- **Module-level LLM singleton**: avoids per-request `ExpertLLMClient` instantiation
- **Dedicated DB session in generator**: prevents use of closed `Depends(get_db)` session
- **50K char cap**: prevents unbounded diagnosis text storage
- **Typed `SessionData` NamedTuple**: replaces bare tuple for `_get_session_data` return

## Test plan

- [ ] Navigate to existing session — verify 4 tabs appear
- [ ] Click "AI Diagnostic Result" tab — see "Generate AI Diagnosis" button
- [ ] Click generate — status spinner appears, then tokens stream in progressively
- [ ] Wait for completion — blinking cursor disappears, full text displayed
- [ ] Refresh page — diagnosis persists (loaded from cache/DB)
- [ ] Submit feedback on AI Diagnosis tab — 201 response
- [ ] Verify `SELECT count(*) FROM obd_ai_diagnosis_feedback` in Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)