### PR TITLE
HARNESS-02: Core agent loop with DI and async generator

### DIFF
--- a/diagnostic_api/app/harness/deps.py
+++ b/diagnostic_api/app/harness/deps.py
@@ -174,6 +174,12 @@ class OpenAILLMClient:
             max_tokens=max_tokens,
         )
 
+        if not response.choices:
+            raise ValueError(
+                "LLM returned empty choices array "
+                "(possible rate limit or content filter)"
+            )
+
         choice = response.choices[0]
         message = choice.message
 

--- a/diagnostic_api/app/harness/deps.py
+++ b/diagnostic_api/app/harness/deps.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Protocol
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+)
 
 import structlog
 from openai import AsyncOpenAI
@@ -57,6 +64,11 @@ class LLMResponse:
     finish_reason: str
 
 
+EventType = Literal[
+    "tool_call", "tool_result", "done", "error",
+]
+
+
 @dataclass(frozen=True)
 class HarnessEvent:
     """Typed event yielded by the agent loop.
@@ -67,7 +79,7 @@ class HarnessEvent:
         payload: Event-specific data dict.
     """
 
-    event_type: str
+    event_type: EventType
     payload: Dict[str, Any]
 
 

--- a/diagnostic_api/app/harness/deps.py
+++ b/diagnostic_api/app/harness/deps.py
@@ -8,8 +8,7 @@ LLM that replays pre-recorded responses.
 
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import (
     Any,
     Dict,

--- a/diagnostic_api/app/harness/deps.py
+++ b/diagnostic_api/app/harness/deps.py
@@ -1,0 +1,217 @@
+"""Dependency injection container and LLM client abstractions.
+
+Provides ``HarnessDeps`` (the DI container passed into the agent loop),
+``HarnessConfig`` (tunable knobs), ``HarnessEvent`` (typed yields), and
+a protocol-based ``LLMClient`` so the loop can be tested with a mock
+LLM that replays pre-recorded responses.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol
+
+import structlog
+from openai import AsyncOpenAI
+
+from app.harness.tool_registry import ToolRegistry
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Data models ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ToolCallInfo:
+    """A single tool-call request from the LLM.
+
+    Attributes:
+        id: Opaque identifier assigned by the API (used to
+            correlate the tool-result message).
+        name: Registered tool name.
+        arguments: Raw JSON string of tool arguments.
+    """
+
+    id: str
+    name: str
+    arguments: str
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Normalised LLM response returned by ``LLMClient.chat()``.
+
+    Attributes:
+        content: Text content (present when the model stops
+            without requesting tool calls).
+        tool_calls: Tool-call requests (non-empty when the
+            model's finish reason is ``"tool_calls"``).
+        finish_reason: ``"stop"`` when the model is done, or
+            ``"tool_calls"`` when it wants to invoke tools.
+    """
+
+    content: Optional[str]
+    tool_calls: List[ToolCallInfo]
+    finish_reason: str
+
+
+@dataclass(frozen=True)
+class HarnessEvent:
+    """Typed event yielded by the agent loop.
+
+    Attributes:
+        event_type: One of ``tool_call``, ``tool_result``,
+            ``done``, or ``error``.
+        payload: Event-specific data dict.
+    """
+
+    event_type: str
+    payload: Dict[str, Any]
+
+
+# ── Configuration ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HarnessConfig:
+    """Tunable knobs for the agent loop.
+
+    Attributes:
+        model: OpenRouter model ID (required, no default).
+        max_iterations: Hard cap on ReAct iterations.
+        max_tokens: Max tokens per LLM call.
+        compact_threshold: Character count that triggers context
+            compaction (placeholder for HARNESS-04).
+        timeout_seconds: Total wall-clock budget for the loop.
+        temperature: LLM sampling temperature.
+    """
+
+    model: str
+    max_iterations: int = 10
+    max_tokens: int = 8192
+    compact_threshold: int = 60_000
+    timeout_seconds: float = 120.0
+    temperature: float = 0.3
+
+
+# ── LLM client protocol + OpenAI adapter ─────────────────────────────
+
+
+class LLMClient(Protocol):
+    """Protocol that any LLM backend must satisfy.
+
+    The agent loop depends only on this interface, so tests can
+    inject a mock that replays pre-recorded responses.
+    """
+
+    async def chat(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> LLMResponse:
+        """Send a chat-completions request and return the result.
+
+        Args:
+            messages: Conversation history in OpenAI format.
+            tools: Tool schemas in OpenAI function-calling format.
+            model: Model identifier.
+            temperature: Sampling temperature.
+            max_tokens: Token budget for the response.
+
+        Returns:
+            Normalised ``LLMResponse``.
+        """
+        ...  # pragma: no cover
+
+
+class OpenAILLMClient:
+    """Adapter that wraps ``AsyncOpenAI`` into ``LLMClient``.
+
+    Converts the SDK response objects into the framework's
+    ``LLMResponse`` / ``ToolCallInfo`` dataclasses so the agent
+    loop never touches vendor-specific types.
+    """
+
+    def __init__(self, client: AsyncOpenAI) -> None:
+        self._client = client
+
+    async def chat(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> LLMResponse:
+        """Call OpenAI-compatible chat completions (non-streaming).
+
+        Args:
+            messages: Conversation history.
+            tools: Tool schemas.
+            model: Model identifier.
+            temperature: Sampling temperature.
+            max_tokens: Token budget.
+
+        Returns:
+            Normalised ``LLMResponse``.
+
+        Raises:
+            openai.PermissionDeniedError: Model blocked in region.
+        """
+        response = await self._client.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+        choice = response.choices[0]
+        message = choice.message
+
+        tool_calls: List[ToolCallInfo] = []
+        if message.tool_calls:
+            for tc in message.tool_calls:
+                tool_calls.append(
+                    ToolCallInfo(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    )
+                )
+
+        finish = choice.finish_reason or "stop"
+        if tool_calls and finish != "tool_calls":
+            finish = "tool_calls"
+
+        return LLMResponse(
+            content=message.content,
+            tool_calls=tool_calls,
+            finish_reason=finish,
+        )
+
+
+# ── Dependency container ─────────────────────────────────────────────
+
+
+@dataclass
+class HarnessDeps:
+    """Injected dependencies for the agent loop.
+
+    Attributes:
+        llm_client: Any object satisfying ``LLMClient`` protocol.
+        tool_registry: The tool dispatch map.
+        config: Tunable knobs.
+    """
+
+    llm_client: LLMClient
+    tool_registry: ToolRegistry
+    config: HarnessConfig

--- a/diagnostic_api/app/harness/harness_prompts.py
+++ b/diagnostic_api/app/harness/harness_prompts.py
@@ -1,0 +1,117 @@
+"""System prompt and user message builders for the agent loop.
+
+The system prompt is dynamic — tool names are injected so the LLM
+knows exactly which tools are available in this session.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+_SYSTEM_PROMPT_TEMPLATE = """\
+You are an expert vehicle diagnostician with access to diagnostic \
+tools. Your task is to investigate OBD-II data, identify faults, \
+and produce a thorough diagnosis.
+
+## Available tools
+
+{tool_list}
+
+## Investigation strategy
+
+1. Start by reviewing the session context to understand the \
+vehicle, DTC codes, and symptom summary.
+2. Use `detect_anomalies` and `get_pid_statistics` to examine \
+sensor data patterns and identify abnormalities.
+3. Use `generate_clues` to obtain rule-based diagnostic hints.
+4. Use `search_manual` to look up relevant service manual \
+sections for the vehicle and suspected faults.
+5. Use `refine_search` if initial manual results are \
+insufficient — try different queries and exclude already-seen \
+document IDs.
+6. Use `search_case_history` to check whether similar DTC \
+patterns have been diagnosed before.
+7. When you have gathered enough evidence, stop calling tools \
+and produce your final diagnosis as plain text.
+
+## Output rules
+
+- When you are ready to conclude, respond with your diagnosis \
+text directly — do NOT call any tools.
+- Structure your diagnosis with: fault identification, root \
+cause analysis, supporting evidence (cite tool results), \
+recommended actions, and limitations.
+- Never invent data. If a tool returned an error or no results, \
+say so explicitly.
+- Cite sources: reference manual sections by doc_id (e.g. \
+MWS150-A#3.2) and tool names that provided evidence.
+- State limitations: if data is missing or inconclusive, say so.
+- Respond in the same language as the user message.\
+"""
+
+
+def build_system_prompt(
+    tool_names: List[str],
+) -> str:
+    """Assemble the dynamic system prompt.
+
+    Args:
+        tool_names: Sorted list of registered tool names.
+
+    Returns:
+        Complete system prompt string with tool list injected.
+    """
+    tool_list = "\n".join(
+        f"- `{name}`" for name in tool_names
+    )
+    return _SYSTEM_PROMPT_TEMPLATE.format(
+        tool_list=tool_list,
+    )
+
+
+_USER_MESSAGE_TEMPLATE = """\
+Diagnose the following OBD-II session.
+
+Vehicle: {vehicle_id}
+Time range: {time_range}
+DTC codes: {dtc_codes}
+PID summary: {pid_summary}
+Anomaly events: {anomaly_events}
+Diagnostic clues: {diagnostic_clues}
+
+Session ID (use this when calling tools): {session_id}\
+"""
+
+
+def build_user_message(
+    session_id: str,
+    parsed_summary: Dict[str, Any],
+) -> str:
+    """Format the initial user message from a parsed summary.
+
+    Args:
+        session_id: OBD analysis session UUID string.
+        parsed_summary: The session's ``parsed_summary_payload``
+            dict with keys like ``vehicle_id``, ``dtc_codes``, etc.
+
+    Returns:
+        Formatted user message string.
+    """
+    return _USER_MESSAGE_TEMPLATE.format(
+        vehicle_id=parsed_summary.get(
+            "vehicle_id", "unknown"
+        ),
+        time_range=parsed_summary.get(
+            "time_range", "unknown"
+        ),
+        dtc_codes=parsed_summary.get("dtc_codes", "none"),
+        pid_summary=parsed_summary.get("pid_summary", "N/A"),
+        anomaly_events=parsed_summary.get(
+            "anomaly_events", "none"
+        ),
+        diagnostic_clues=parsed_summary.get(
+            "diagnostic_clues", "none"
+        ),
+        session_id=session_id,
+    )

--- a/diagnostic_api/app/harness/loop.py
+++ b/diagnostic_api/app/harness/loop.py
@@ -29,6 +29,28 @@ from app.harness.harness_prompts import (
 
 logger = structlog.get_logger(__name__)
 
+_MAX_ERROR_LEN = 200  # Cap for user-facing error messages.
+
+
+def _sanitize_llm_error(exc: Exception) -> str:
+    """Build a safe error string from an LLM exception.
+
+    Extracts only the exception class name and a truncated
+    message.  API keys, internal URLs, and stack traces are
+    logged internally but never sent to the SSE stream.
+
+    Args:
+        exc: The caught exception.
+
+    Returns:
+        Sanitised error string (max ``_MAX_ERROR_LEN`` chars).
+    """
+    exc_name = type(exc).__name__
+    exc_msg = str(exc)
+    if len(exc_msg) > _MAX_ERROR_LEN:
+        exc_msg = exc_msg[:_MAX_ERROR_LEN] + "..."
+    return f"LLM call failed ({exc_name}: {exc_msg})"
+
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -236,13 +258,14 @@ async def run_diagnosis_loop(
                         "harness_llm_error",
                         session_id=sid,
                         iteration=iteration,
-                        error=str(exc),
+                        exc_info=exc,
                     )
+                    safe_msg = _sanitize_llm_error(exc)
                     yield HarnessEvent(
                         "error",
                         {
                             "error_type": "llm_error",
-                            "message": str(exc),
+                            "message": safe_msg,
                             "iteration": iteration,
                         },
                     )

--- a/diagnostic_api/app/harness/loop.py
+++ b/diagnostic_api/app/harness/loop.py
@@ -1,0 +1,379 @@
+"""Core agent loop implementing the ReAct diagnosis cycle.
+
+The loop is an async generator that yields ``HarnessEvent`` objects
+consumable by SSE streaming.  It calls the LLM with tool schemas,
+dispatches tool calls through ``ToolRegistry.execute()``, appends
+results to the conversation, and iterates until the LLM produces a
+final diagnosis or the iteration / timeout budget is exhausted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+import structlog
+
+from app.harness.deps import (
+    HarnessDeps,
+    HarnessEvent,
+    LLMResponse,
+    ToolCallInfo,
+)
+from app.harness.harness_prompts import (
+    build_system_prompt,
+    build_user_message,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _build_initial_messages(
+    session_id: str,
+    parsed_summary: Dict[str, Any],
+    tool_names: List[str],
+) -> List[Dict[str, Any]]:
+    """Assemble the opening system + user messages.
+
+    Args:
+        session_id: OBD session UUID string.
+        parsed_summary: Session's ``parsed_summary_payload``.
+        tool_names: Sorted list of registered tool names.
+
+    Returns:
+        Two-element message list (system, user).
+    """
+    return [
+        {
+            "role": "system",
+            "content": build_system_prompt(tool_names),
+        },
+        {
+            "role": "user",
+            "content": build_user_message(
+                session_id, parsed_summary,
+            ),
+        },
+    ]
+
+
+def _parse_tool_arguments(
+    raw: str,
+) -> Dict[str, Any]:
+    """Safely parse a JSON arguments string.
+
+    Args:
+        raw: JSON string from ``ToolCallInfo.arguments``.
+
+    Returns:
+        Parsed dict, or a dict with ``"_parse_error"`` key on
+        failure so the registry can return a validation error.
+
+    Raises:
+        Never — all parse errors are caught and wrapped.
+    """
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+        return {"_parse_error": f"Expected object, got {type(parsed).__name__}"}
+    except (json.JSONDecodeError, TypeError) as exc:
+        return {"_parse_error": str(exc)}
+
+
+def _make_assistant_message(
+    response: LLMResponse,
+) -> Dict[str, Any]:
+    """Build the assistant message to append to history.
+
+    Args:
+        response: The LLM response containing tool calls.
+
+    Returns:
+        OpenAI-format assistant message dict.
+    """
+    msg: Dict[str, Any] = {
+        "role": "assistant",
+        "content": response.content,
+    }
+    if response.tool_calls:
+        msg["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.name,
+                    "arguments": tc.arguments,
+                },
+            }
+            for tc in response.tool_calls
+        ]
+    return msg
+
+
+def _make_tool_message(
+    tool_call_id: str,
+    output: str,
+) -> Dict[str, Any]:
+    """Build a tool-result message for the conversation.
+
+    Args:
+        tool_call_id: Correlating ID from the tool call.
+        output: Tool execution output string.
+
+    Returns:
+        OpenAI-format tool message dict.
+    """
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": output,
+    }
+
+
+def _extract_diagnosis(content: Optional[str]) -> str:
+    """Extract diagnosis text from the LLM's final response.
+
+    Args:
+        content: The ``content`` field of the LLM response.
+
+    Returns:
+        Diagnosis text, or a fallback string if empty.
+    """
+    if content and content.strip():
+        return content.strip()
+    return (
+        "The agent completed its investigation but did not "
+        "produce a final diagnosis text."
+    )
+
+
+def _extract_partial_diagnosis(
+    messages: List[Dict[str, Any]],
+) -> str:
+    """Scan conversation history for the best diagnosis attempt.
+
+    Looks for the last assistant message with non-empty content
+    (which may be an intermediate reasoning step).
+
+    Args:
+        messages: Full conversation history.
+
+    Returns:
+        Best available diagnosis text.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            content = msg.get("content")
+            if content and content.strip():
+                return content.strip()
+    return (
+        "Max iterations reached. The agent could not produce "
+        "a diagnosis within the allowed number of steps."
+    )
+
+
+# ── Core loop ────────────────────────────────────────────────────────
+
+
+async def run_diagnosis_loop(
+    session_id: uuid.UUID,
+    parsed_summary: Dict[str, Any],
+    deps: HarnessDeps,
+) -> AsyncIterator[HarnessEvent]:
+    """Core agent loop for diagnosis investigation.
+
+    Implements the ReAct cycle: call LLM → dispatch tool calls →
+    append results → iterate until the LLM stops or the budget
+    is exhausted.
+
+    Args:
+        session_id: OBD analysis session to diagnose.
+        parsed_summary: Pre-computed summary from V1 pipeline.
+        deps: Injected dependencies (LLM client, tools, config).
+
+    Yields:
+        ``HarnessEvent`` with ``event_type`` and ``payload``.
+    """
+    sid = str(session_id)
+    cfg = deps.config
+    tool_schemas = deps.tool_registry.schemas
+    tool_names = deps.tool_registry.tool_names
+
+    messages = _build_initial_messages(
+        sid, parsed_summary, tool_names,
+    )
+
+    iteration = 0
+    total_tool_calls: List[str] = []
+
+    logger.info(
+        "harness_loop_start",
+        session_id=sid,
+        model=cfg.model,
+        max_iterations=cfg.max_iterations,
+    )
+
+    try:
+        async with asyncio.timeout(cfg.timeout_seconds):
+            while iteration < cfg.max_iterations:
+                # ── 1. Call LLM ──────────────────────────────
+                try:
+                    response = await deps.llm_client.chat(
+                        messages=messages,
+                        tools=tool_schemas,
+                        model=cfg.model,
+                        temperature=cfg.temperature,
+                        max_tokens=cfg.max_tokens,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "harness_llm_error",
+                        session_id=sid,
+                        iteration=iteration,
+                        error=str(exc),
+                    )
+                    yield HarnessEvent(
+                        "error",
+                        {
+                            "error_type": "llm_error",
+                            "message": str(exc),
+                            "iteration": iteration,
+                        },
+                    )
+                    partial = _extract_partial_diagnosis(
+                        messages,
+                    )
+                    yield HarnessEvent(
+                        "done",
+                        {
+                            "diagnosis": partial,
+                            "partial": True,
+                            "iterations": iteration,
+                            "tools_called": total_tool_calls,
+                        },
+                    )
+                    return
+
+                # ── 2. Check if LLM wants to stop ───────────
+                if (
+                    response.finish_reason == "stop"
+                    or not response.tool_calls
+                ):
+                    diagnosis = _extract_diagnosis(
+                        response.content,
+                    )
+                    logger.info(
+                        "harness_loop_done",
+                        session_id=sid,
+                        iterations=iteration + 1,
+                        tools_called=total_tool_calls,
+                    )
+                    yield HarnessEvent(
+                        "done",
+                        {
+                            "diagnosis": diagnosis,
+                            "partial": False,
+                            "iterations": iteration + 1,
+                            "tools_called": total_tool_calls,
+                        },
+                    )
+                    return
+
+                # ── 3. Execute tool calls ────────────────────
+                messages.append(
+                    _make_assistant_message(response),
+                )
+
+                for tc in response.tool_calls:
+                    args = _parse_tool_arguments(
+                        tc.arguments,
+                    )
+
+                    yield HarnessEvent(
+                        "tool_call",
+                        {
+                            "name": tc.name,
+                            "input": args,
+                            "iteration": iteration,
+                            "tool_call_id": tc.id,
+                        },
+                    )
+
+                    result = (
+                        await deps.tool_registry.execute(
+                            tc.name, args,
+                        )
+                    )
+                    total_tool_calls.append(tc.name)
+
+                    yield HarnessEvent(
+                        "tool_result",
+                        {
+                            "name": tc.name,
+                            "output": result.output,
+                            "duration_ms": result.duration_ms,
+                            "is_error": result.is_error,
+                            "iteration": iteration,
+                        },
+                    )
+
+                    messages.append(
+                        _make_tool_message(
+                            tc.id, result.output,
+                        ),
+                    )
+
+                iteration += 1
+
+    except TimeoutError:
+        logger.warning(
+            "harness_loop_timeout",
+            session_id=sid,
+            iteration=iteration,
+            timeout_seconds=cfg.timeout_seconds,
+        )
+        yield HarnessEvent(
+            "error",
+            {
+                "error_type": "timeout",
+                "message": (
+                    f"Agent loop timed out after "
+                    f"{cfg.timeout_seconds}s"
+                ),
+                "iteration": iteration,
+            },
+        )
+        partial = _extract_partial_diagnosis(messages)
+        yield HarnessEvent(
+            "done",
+            {
+                "diagnosis": partial,
+                "partial": True,
+                "iterations": iteration,
+                "tools_called": total_tool_calls,
+            },
+        )
+        return
+
+    # ── Max iterations reached ───────────────────────────────────
+    logger.warning(
+        "harness_loop_max_iterations",
+        session_id=sid,
+        max_iterations=cfg.max_iterations,
+    )
+    partial = _extract_partial_diagnosis(messages)
+    yield HarnessEvent(
+        "done",
+        {
+            "diagnosis": partial,
+            "partial": True,
+            "iterations": cfg.max_iterations,
+            "tools_called": total_tool_calls,
+        },
+    )

--- a/diagnostic_api/tests/harness/test_loop.py
+++ b/diagnostic_api/tests/harness/test_loop.py
@@ -1,0 +1,716 @@
+"""Tests for the core agent loop (``app.harness.loop``).
+
+Uses a ``MockLLMClient`` that replays pre-recorded responses so
+every test is deterministic — no real LLM calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import pytest
+
+from app.harness.deps import (
+    HarnessConfig,
+    HarnessDeps,
+    HarnessEvent,
+    LLMResponse,
+    ToolCallInfo,
+)
+from app.harness.loop import (
+    _build_initial_messages,
+    _extract_diagnosis,
+    _extract_partial_diagnosis,
+    _parse_tool_arguments,
+    run_diagnosis_loop,
+)
+from app.harness.tool_registry import (
+    ToolDefinition,
+    ToolRegistry,
+    ToolResult,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+FAKE_SESSION_ID = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+FAKE_PARSED_SUMMARY: Dict[str, Any] = {
+    "vehicle_id": "V12345",
+    "time_range": "2026-04-01 08:00 – 2026-04-01 09:00",
+    "dtc_codes": "P0300 (Random/Multiple Cylinder Misfire)",
+    "pid_summary": "RPM: 780-4200, COOLANT_TEMP: 89-95",
+    "anomaly_events": "RPM range_shift at 08:32",
+    "diagnostic_clues": "STAT_001 Engine misfire pattern",
+}
+
+
+# ── Mock LLM Client ─────────────────────────────────────────────────
+
+
+class MockLLMClient:
+    """LLM client that replays a sequence of pre-recorded responses.
+
+    Attributes:
+        responses: Ordered list of ``LLMResponse`` to return.
+        calls: Recorded call kwargs for assertions.
+    """
+
+    def __init__(
+        self, responses: List[LLMResponse],
+    ) -> None:
+        self._responses = list(responses)
+        self._index = 0
+        self.calls: List[Dict[str, Any]] = []
+
+    async def chat(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]],
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> LLMResponse:
+        """Return the next pre-recorded response."""
+        self.calls.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "model": model,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+        )
+        if self._index >= len(self._responses):
+            raise RuntimeError(
+                "MockLLMClient exhausted all responses"
+            )
+        resp = self._responses[self._index]
+        self._index += 1
+        return resp
+
+
+class SlowMockLLMClient:
+    """LLM client that sleeps to trigger timeout."""
+
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        """Sleep indefinitely until cancelled."""
+        await asyncio.sleep(999)
+        raise RuntimeError("unreachable")
+
+
+class ErrorMockLLMClient:
+    """LLM client that raises on the first call."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def chat(self, **kwargs: Any) -> LLMResponse:
+        """Raise the configured error."""
+        raise self._error
+
+
+# ── Helper: build a registry with simple echo tools ──────────────────
+
+
+def _echo_tool(name: str) -> ToolDefinition:
+    """Create a simple tool that echoes its input as a string."""
+
+    async def handler(
+        input_data: Dict[str, Any],
+    ) -> str:
+        return f"{name} result: {input_data}"
+
+    return ToolDefinition(
+        name=name,
+        description=f"Echo tool: {name}",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+            },
+            "required": ["session_id"],
+        },
+        handler=handler,
+    )
+
+
+def _make_registry(
+    *tool_names: str,
+) -> ToolRegistry:
+    """Build a registry with echo tools for testing."""
+    registry = ToolRegistry()
+    for name in tool_names:
+        registry.register(_echo_tool(name))
+    return registry
+
+
+def _make_deps(
+    client: Any,
+    registry: ToolRegistry | None = None,
+    **config_overrides: Any,
+) -> HarnessDeps:
+    """Build HarnessDeps with sensible test defaults."""
+    if registry is None:
+        registry = _make_registry(
+            "get_session_context",
+            "detect_anomalies",
+            "search_manual",
+        )
+    config_kwargs: Dict[str, Any] = {
+        "model": "test/mock-model",
+        "max_iterations": 10,
+        "timeout_seconds": 30.0,
+    }
+    config_kwargs.update(config_overrides)
+    return HarnessDeps(
+        llm_client=client,
+        tool_registry=registry,
+        config=HarnessConfig(**config_kwargs),
+    )
+
+
+async def _collect_events(
+    gen: AsyncIterator[HarnessEvent],
+) -> List[HarnessEvent]:
+    """Drain an async generator into a list."""
+    events: List[HarnessEvent] = []
+    async for event in gen:
+        events.append(event)
+    return events
+
+
+# ── Helper responses ─────────────────────────────────────────────────
+
+
+def _tool_call_response(
+    *calls: tuple[str, str, str],
+) -> LLMResponse:
+    """Build an LLMResponse with tool calls.
+
+    Args:
+        calls: Tuples of (id, name, arguments_json).
+    """
+    return LLMResponse(
+        content=None,
+        tool_calls=[
+            ToolCallInfo(id=c[0], name=c[1], arguments=c[2])
+            for c in calls
+        ],
+        finish_reason="tool_calls",
+    )
+
+
+def _stop_response(content: str) -> LLMResponse:
+    """Build an LLMResponse that ends the loop."""
+    return LLMResponse(
+        content=content,
+        tool_calls=[],
+        finish_reason="stop",
+    )
+
+
+# ── Tests: helper functions ──────────────────────────────────────────
+
+
+class TestHelpers:
+    """Tests for loop helper functions."""
+
+    def test_parse_tool_arguments_valid(self) -> None:
+        """Valid JSON object is parsed correctly."""
+        result = _parse_tool_arguments(
+            '{"session_id": "abc"}'
+        )
+        assert result == {"session_id": "abc"}
+
+    def test_parse_tool_arguments_invalid_json(self) -> None:
+        """Invalid JSON returns a dict with _parse_error."""
+        result = _parse_tool_arguments("not json")
+        assert "_parse_error" in result
+
+    def test_parse_tool_arguments_non_object(self) -> None:
+        """Valid JSON that is not an object returns error."""
+        result = _parse_tool_arguments("[1, 2, 3]")
+        assert "_parse_error" in result
+
+    def test_extract_diagnosis_with_content(self) -> None:
+        """Non-empty content is returned stripped."""
+        assert _extract_diagnosis("  Diagnosis.  ") == (
+            "Diagnosis."
+        )
+
+    def test_extract_diagnosis_empty(self) -> None:
+        """Empty content returns fallback string."""
+        result = _extract_diagnosis(None)
+        assert "did not produce" in result
+
+    def test_extract_partial_from_history(self) -> None:
+        """Partial extraction finds last assistant content."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "usr"},
+            {
+                "role": "assistant",
+                "content": "first thought",
+            },
+            {"role": "tool", "content": "tool output"},
+            {
+                "role": "assistant",
+                "content": "refined thought",
+            },
+        ]
+        assert _extract_partial_diagnosis(messages) == (
+            "refined thought"
+        )
+
+    def test_extract_partial_no_assistant(self) -> None:
+        """No assistant messages returns fallback."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "usr"},
+        ]
+        result = _extract_partial_diagnosis(messages)
+        assert "Max iterations" in result
+
+    def test_build_initial_messages(self) -> None:
+        """Initial messages contain system and user roles."""
+        msgs = _build_initial_messages(
+            str(FAKE_SESSION_ID),
+            FAKE_PARSED_SUMMARY,
+            ["detect_anomalies", "search_manual"],
+        )
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "system"
+        assert msgs[1]["role"] == "user"
+        assert "V12345" in msgs[1]["content"]
+        assert str(FAKE_SESSION_ID) in msgs[1]["content"]
+
+
+# ── Tests: agent loop ────────────────────────────────────────────────
+
+
+class TestGoldenPath:
+    """Golden-path tests: LLM calls tools then produces diagnosis."""
+
+    @pytest.mark.asyncio
+    async def test_three_tools_then_diagnosis(self) -> None:
+        """LLM calls 3 tools then stops with a diagnosis.
+
+        Verifies correct event sequence: 3x (tool_call, tool_result)
+        then 1x done.
+        """
+        sid = '{"session_id": "aaa"}'
+        client = MockLLMClient(
+            [
+                _tool_call_response(
+                    ("tc1", "get_session_context", sid),
+                ),
+                _tool_call_response(
+                    ("tc2", "detect_anomalies", sid),
+                ),
+                _tool_call_response(
+                    ("tc3", "search_manual",
+                     '{"query": "misfire"}'),
+                ),
+                _stop_response(
+                    "Diagnosis: P0300 misfire due to "
+                    "ignition coil failure."
+                ),
+            ]
+        )
+
+        deps = _make_deps(client)
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        types = [e.event_type for e in events]
+        assert types == [
+            "tool_call", "tool_result",
+            "tool_call", "tool_result",
+            "tool_call", "tool_result",
+            "done",
+        ]
+
+        done = events[-1]
+        assert done.payload["partial"] is False
+        assert "P0300" in done.payload["diagnosis"]
+        assert done.payload["iterations"] == 4
+        assert len(done.payload["tools_called"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_immediate_diagnosis_no_tools(self) -> None:
+        """LLM returns diagnosis on first call without tools.
+
+        Verifies single done event.
+        """
+        client = MockLLMClient(
+            [_stop_response("Simple diagnosis.")]
+        )
+        deps = _make_deps(client)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        assert len(events) == 1
+        assert events[0].event_type == "done"
+        assert events[0].payload["partial"] is False
+        assert events[0].payload["iterations"] == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_tools_in_one_call(self) -> None:
+        """LLM requests 2 tool calls in a single response.
+
+        Verifies both are dispatched and results yielded.
+        """
+        client = MockLLMClient(
+            [
+                _tool_call_response(
+                    ("tc1", "detect_anomalies",
+                     '{"session_id": "x"}'),
+                    ("tc2", "search_manual",
+                     '{"query": "rpm"}'),
+                ),
+                _stop_response("Dual-tool diagnosis."),
+            ]
+        )
+        deps = _make_deps(client)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        types = [e.event_type for e in events]
+        assert types == [
+            "tool_call", "tool_result",
+            "tool_call", "tool_result",
+            "done",
+        ]
+        assert events[-1].payload["tools_called"] == [
+            "detect_anomalies",
+            "search_manual",
+        ]
+
+
+class TestErrorHandling:
+    """Tests for error conditions and recovery."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_error_then_recovery(
+        self,
+    ) -> None:
+        """LLM calls unknown tool; gets error; self-corrects.
+
+        Verifies the error result is returned to the LLM and the
+        loop continues.
+        """
+        client = MockLLMClient(
+            [
+                _tool_call_response(
+                    ("tc1", "nonexistent_tool",
+                     '{"session_id": "x"}'),
+                ),
+                _stop_response(
+                    "Recovered diagnosis after error."
+                ),
+            ]
+        )
+        deps = _make_deps(client)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        types = [e.event_type for e in events]
+        assert types == [
+            "tool_call", "tool_result", "done",
+        ]
+
+        tool_result = events[1]
+        assert tool_result.payload["is_error"] is True
+        assert (
+            "unknown tool" in tool_result.payload["output"].lower()
+        )
+
+        done = events[-1]
+        assert "Recovered" in done.payload["diagnosis"]
+
+    @pytest.mark.asyncio
+    async def test_tool_execution_error_continues(
+        self,
+    ) -> None:
+        """Tool handler raises an exception; loop continues.
+
+        The registry catches the exception and returns an error
+        string.  The LLM receives it and can self-correct.
+        """
+        async def failing_handler(
+            input_data: Dict[str, Any],
+        ) -> str:
+            raise RuntimeError("DB connection lost")
+
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="failing_tool",
+                description="Always fails",
+                input_schema={
+                    "type": "object",
+                    "properties": {},
+                },
+                handler=failing_handler,
+            )
+        )
+
+        client = MockLLMClient(
+            [
+                _tool_call_response(
+                    ("tc1", "failing_tool", "{}"),
+                ),
+                _stop_response("Diagnosis despite error."),
+            ]
+        )
+        deps = _make_deps(client, registry=registry)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        tool_result = [
+            e for e in events
+            if e.event_type == "tool_result"
+        ][0]
+        assert tool_result.payload["is_error"] is True
+        assert "RuntimeError" in tool_result.payload["output"]
+
+        done = events[-1]
+        assert done.event_type == "done"
+        assert done.payload["partial"] is False
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_args_handled(self) -> None:
+        """LLM sends invalid JSON as tool arguments.
+
+        The parse error is forwarded as tool input and the
+        registry returns a validation error.
+        """
+        client = MockLLMClient(
+            [
+                LLMResponse(
+                    content=None,
+                    tool_calls=[
+                        ToolCallInfo(
+                            id="tc1",
+                            name="get_session_context",
+                            arguments="not valid json!!!",
+                        ),
+                    ],
+                    finish_reason="tool_calls",
+                ),
+                _stop_response("Recovered from bad args."),
+            ]
+        )
+        deps = _make_deps(client)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        tool_result = [
+            e for e in events
+            if e.event_type == "tool_result"
+        ][0]
+        assert tool_result.payload["is_error"] is True
+
+    @pytest.mark.asyncio
+    async def test_llm_error_yields_error_and_partial(
+        self,
+    ) -> None:
+        """LLM client raises an exception on the first call.
+
+        Verifies: error event yielded, then done with partial.
+        """
+        client = ErrorMockLLMClient(
+            RuntimeError("API unreachable"),
+        )
+        deps = _make_deps(client)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        types = [e.event_type for e in events]
+        assert types == ["error", "done"]
+        assert events[0].payload["error_type"] == "llm_error"
+        assert events[1].payload["partial"] is True
+
+
+class TestBudgetLimits:
+    """Tests for iteration and timeout budgets."""
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_partial_diagnosis(
+        self,
+    ) -> None:
+        """LLM always calls tools and never stops voluntarily.
+
+        Verifies: loop stops at max_iterations, yields done with
+        partial=True.
+        """
+        responses = [
+            _tool_call_response(
+                (f"tc{i}", "detect_anomalies",
+                 '{"session_id": "x"}'),
+            )
+            for i in range(5)
+        ]
+        client = MockLLMClient(responses)
+        deps = _make_deps(client, max_iterations=3)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        done = events[-1]
+        assert done.event_type == "done"
+        assert done.payload["partial"] is True
+        assert done.payload["iterations"] == 3
+
+        tool_calls = [
+            e for e in events
+            if e.event_type == "tool_call"
+        ]
+        assert len(tool_calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_timeout_yields_error_event(self) -> None:
+        """Agent loop times out when LLM is too slow.
+
+        Verifies: error event with type=timeout, then done with
+        partial=True.
+        """
+        client = SlowMockLLMClient()
+        deps = _make_deps(client, timeout_seconds=0.05)
+
+        events = await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        types = [e.event_type for e in events]
+        assert "error" in types
+        error_event = [
+            e for e in events if e.event_type == "error"
+        ][0]
+        assert error_event.payload["error_type"] == "timeout"
+
+        done = events[-1]
+        assert done.event_type == "done"
+        assert done.payload["partial"] is True
+
+
+class TestMessageHistory:
+    """Tests that verify correct message construction."""
+
+    @pytest.mark.asyncio
+    async def test_tool_results_appended_to_messages(
+        self,
+    ) -> None:
+        """Tool results are appended as 'tool' role messages.
+
+        Verifies the LLM receives the full conversation history
+        including tool results on subsequent calls.
+        """
+        client = MockLLMClient(
+            [
+                _tool_call_response(
+                    ("tc1", "detect_anomalies",
+                     '{"session_id": "x"}'),
+                ),
+                _stop_response("Final."),
+            ]
+        )
+        deps = _make_deps(client)
+
+        await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        second_call = client.calls[1]
+        messages = second_call["messages"]
+
+        roles = [m["role"] for m in messages]
+        assert roles == [
+            "system", "user", "assistant", "tool",
+        ]
+
+        tool_msg = messages[-1]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "tc1"
+
+    @pytest.mark.asyncio
+    async def test_model_passed_to_llm(self) -> None:
+        """Config model is passed to every LLM call."""
+        client = MockLLMClient(
+            [_stop_response("Done.")]
+        )
+        deps = _make_deps(
+            client, model="deepseek/deepseek-v3.2",
+        )
+
+        await _collect_events(
+            run_diagnosis_loop(
+                FAKE_SESSION_ID,
+                FAKE_PARSED_SUMMARY,
+                deps,
+            )
+        )
+
+        assert client.calls[0]["model"] == (
+            "deepseek/deepseek-v3.2"
+        )

--- a/diagnostic_api/tests/harness/test_loop.py
+++ b/diagnostic_api/tests/harness/test_loop.py
@@ -25,6 +25,7 @@ from app.harness.loop import (
     _extract_diagnosis,
     _extract_partial_diagnosis,
     _parse_tool_arguments,
+    _sanitize_llm_error,
     run_diagnosis_loop,
 )
 from app.harness.tool_registry import (
@@ -289,6 +290,23 @@ class TestHelpers:
         assert msgs[1]["role"] == "user"
         assert "V12345" in msgs[1]["content"]
         assert str(FAKE_SESSION_ID) in msgs[1]["content"]
+
+    def test_sanitize_llm_error_short(self) -> None:
+        """Short error messages are preserved with class name."""
+        result = _sanitize_llm_error(
+            ValueError("bad input"),
+        )
+        assert "ValueError" in result
+        assert "bad input" in result
+
+    def test_sanitize_llm_error_truncated(self) -> None:
+        """Long error messages are truncated to 200 chars."""
+        long_msg = "x" * 500
+        result = _sanitize_llm_error(
+            RuntimeError(long_msg),
+        )
+        assert len(result) < 300
+        assert "..." in result
 
 
 # ── Tests: agent loop ────────────────────────────────────────────────
@@ -576,6 +594,10 @@ class TestErrorHandling:
         types = [e.event_type for e in events]
         assert types == ["error", "done"]
         assert events[0].payload["error_type"] == "llm_error"
+        # Error message is sanitised (class name + truncated msg).
+        msg = events[0].payload["message"]
+        assert "RuntimeError" in msg
+        assert "API unreachable" in msg
         assert events[1].payload["partial"] is True
 
 

--- a/docs/v2_design_doc.md
+++ b/docs/v2_design_doc.md
@@ -8,18 +8,19 @@
 |-------|-------|
 | **Doc title** | V2 Harness Architecture for AI-Assisted Vehicle Diagnosis |
 | **Project** | STF AI Diagnosis Platform — Phase 1 Pilot |
-| **Status** | Draft v0.1 |
+| **Status** | Draft v0.2 |
 | **Owner** | Li-Ta Hsu |
 | **Contributors** | ML engineers; backend engineers; frontend engineers |
-| **Last updated** | 2026-04-10 (v0.1) |
+| **Last updated** | 2026-04-10 (v0.2) |
 | **Primary pilot stack** | FastAPI + AsyncOpenAI (OpenRouter) + Ollama + pgvector (PostgreSQL) + Next.js |
-| **New in this revision** | Initial V2 design document. Harness-based diagnosis architecture with agent loop, tool registry, session event log, context management, and graduated autonomy. GitHub Issue #26. |
+| **New in this revision** | HARNESS-02 implemented: core agent loop (`run_diagnosis_loop` async generator), `HarnessDeps` DI container with `LLMClient` protocol, `OpenAILLMClient` adapter, `HarnessConfig`, dynamic system prompt. GitHub Issue #52. |
 
 ### Revision history
 
 | Version | Date | Summary |
 |---------|------|---------|
 | v0.1 | 2026-04-10 | Initial draft. Defines harness architecture for agent-driven diagnosis. 5-component model (Tools, Session, Harness, Sandbox, Orchestration). 7 diagnostic tools (4 wrapped from V1 + 3 new). Graduated autonomy with 4 tiers. New API endpoint, SSE event types, HarnessEventLog table. GitHub Issue #26. |
+| v0.2 | 2026-04-10 | HARNESS-02: Core agent loop implemented. `run_diagnosis_loop()` async generator with ReAct cycle, `HarnessDeps` DI, `LLMClient` protocol + `OpenAILLMClient` adapter, `HarnessConfig`, dynamic system prompt assembly. 19 unit tests. GitHub Issue #52. |
 
 ### Relationship to V1
 

--- a/docs/v2_dev_plan.md
+++ b/docs/v2_dev_plan.md
@@ -147,10 +147,11 @@ Acceptance Criteria:
 
 ---
 
-#### HARNESS‑02 — Core Agent Loop
+#### HARNESS‑02 — Core Agent Loop ✅ DONE
 
 Owner: AI Application Engineer
 Depends on: HARNESS-01
+Status: **DONE** — GitHub Issue #52
 
 PROMPT (task ticket):
 Title: HARNESS‑02 Implement core agent loop as async generator with dependency injection
@@ -518,3 +519,4 @@ Scope: Use stored expert feedback to build a case library. Tool retrieves past c
 |------|---------|---------|
 | 2026-04-10 | v1.0 | Initial V2 dev plan. 8 tickets (HARNESS-01 through HARNESS-08) across 2 phases. 4 future tickets (HARNESS-09 through HARNESS-12). Scope: core harness loop, 7 tools, session event log, context management, API endpoint, graduated autonomy, frontend visualization, integration tests. GitHub Issue #26. |
 | 2026-04-10 | v1.1 | HARNESS-01 implemented (GitHub Issue #51). Tool registry (`ToolRegistry`, `ToolDefinition`) with dispatch map and 7 diagnostic tool wrappers. OBD tools read from `result_payload` JSONB (no re-run). 27 unit tests passing. Files: `harness/tool_registry.py`, `harness_tools/{obd,rag,history}_tools.py`. |
+| 2026-04-10 | v1.2 | HARNESS-02 implemented (GitHub Issue #52). Core agent loop (`run_diagnosis_loop`) as async generator with DI. `HarnessDeps` container with `LLMClient` protocol, `OpenAILLMClient` adapter, `HarnessConfig`. Dynamic system prompt via `harness_prompts.py`. ReAct cycle with max-iteration guard, timeout handling, partial diagnosis extraction. 19 unit tests (golden-path, error recovery, budget limits, message history). Files: `harness/{deps,loop,harness_prompts}.py`, `tests/harness/test_loop.py`. |


### PR DESCRIPTION
## Summary
- Implements `run_diagnosis_loop()` async generator with ReAct cycle (call LLM → dispatch tools → append results → iterate)
- `HarnessDeps` DI container with `LLMClient` protocol + `OpenAILLMClient` adapter for testability
- `HarnessConfig` with configurable max_iterations, timeout, temperature, model
- Dynamic system prompt assembly via `harness_prompts.py`
- 21 unit tests with `MockLLMClient` (deterministic replay, no real LLM calls)

### Production comparison fixes (vs Claude Code reference)
- Sanitize LLM error messages before SSE stream (cap 200 chars)
- Guard empty `choices` array in OpenAI adapter
- Constrain `HarnessEvent.event_type` with `Literal` type
- Remove unused imports

Closes #52

## Test plan
- [x] `pytest tests/harness/test_loop.py` — 21 tests (golden-path, error recovery, budget limits, message history)
- [x] `pytest tests/harness/` — 52 tests total, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)