### PR TITLE
HARNESS-19 [3/5]: six OBD investigation primitives

### DIFF
--- a/diagnostic_api/app/harness_agents/types.py
+++ b/diagnostic_api/app/harness_agents/types.py
@@ -14,7 +14,7 @@ Author: Li-Ta Hsu
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -97,6 +97,108 @@ class ManualAgentResult(BaseModel):
     summary: str
     citations: List[Citation] = Field(default_factory=list)
     raw_sections: List[SectionRef] = Field(default_factory=list)
+    tool_trace: List[ToolCallTrace] = Field(default_factory=list)
+    iterations: int = 0
+    total_tokens: int = 0
+    stopped_reason: StoppedReason = "complete"
+
+
+# ── OBD sub-agent types ───────────────────────────────────────────
+
+
+class SignalCitation(BaseModel):
+    """One signal/timestamp reference produced by the OBD sub-agent.
+
+    Parallel to ``Citation`` for the manual sub-agent — same role but
+    addresses time-series data rather than manual prose.
+
+    Attributes:
+        signal: Signal/column name (e.g. ``RPM`` or
+            ``A_YAM_INJ_MS``).
+        time_range: Optional ISO start/end the citation refers to.
+            Omitted for whole-session references.
+        value: Optional point or statistic value.
+        stat: Name of the statistic when ``value`` is an aggregate
+            (e.g. ``"p95"``, ``"mean"``, ``"max"``).
+        units: Engineering units for ``value``.
+    """
+
+    signal: str
+    time_range: Optional[Tuple[str, str]] = None
+    value: Optional[float] = None
+    stat: Optional[str] = None
+    units: Optional[str] = None
+
+
+class DTCCitation(BaseModel):
+    """One DTC reference produced by the OBD sub-agent.
+
+    Attributes:
+        code: DTC code string — either standard P/C/B/U format
+            (e.g. ``"P0117"``) or Yamaha-proprietary raw hex
+            (e.g. ``"87F11043000000000000CB"``).
+        status: Whether the code is stored or pending.
+        ecu: Originating ECU label (e.g. ``"K-Line"``,
+            ``"CAN-ABS"``).
+    """
+
+    code: str
+    status: Literal["stored", "pending"]
+    ecu: Optional[str] = None
+
+
+DataExcerptKind = Literal["stats", "events", "window", "dtcs"]
+"""Tag for the kind of tool output preserved in ``DataExcerpt``."""
+
+
+class DataExcerpt(BaseModel):
+    """Verbatim tool-output block the OBD sub-agent pulled.
+
+    Used so the main agent can quote the sub-agent's evidence
+    directly rather than re-deriving it.  ``payload`` preserves the
+    shape of the tool's output dict — schema varies per ``kind``.
+
+    Attributes:
+        kind: Which tool produced this excerpt.
+        payload: Tool-output content (stats dict, event list,
+            window samples, DTC entry).
+    """
+
+    kind: DataExcerptKind
+    payload: Dict[str, Any]
+
+
+class OBDAgentResult(BaseModel):
+    """Full output of one OBD-agent run.
+
+    Mirrors ``ManualAgentResult`` where structurally identical and
+    diverges where OBD data shape requires it.  Two citation lists
+    (signal + DTC) instead of one polymorphic list — signals and
+    DTCs live in different conceptual spaces.  ``limitations`` is
+    additive: the OBD sub-agent frequently needs to flag missing
+    data (Channel B not present, Yamaha-hex not decodable,
+    freeze-frame absent) for the main agent.
+
+    Attributes:
+        summary: 3-5 sentence answer to the inquiry.
+        signal_citations: Signal/time-range references.
+        dtc_citations: DTC references.
+        raw_data: Tool-output excerpts the main agent can quote.
+        limitations: Concrete reasons something could not be
+            answered (e.g. ``"Yamaha hex DTC not decodable"``).
+        tool_trace: Ordered list of tool invocations.
+        iterations: ReAct cycles consumed.
+        total_tokens: Approximate input + output token total.
+        stopped_reason: Why the loop ended.
+    """
+
+    summary: str
+    signal_citations: List[SignalCitation] = Field(
+        default_factory=list,
+    )
+    dtc_citations: List[DTCCitation] = Field(default_factory=list)
+    raw_data: List[DataExcerpt] = Field(default_factory=list)
+    limitations: List[str] = Field(default_factory=list)
     tool_trace: List[ToolCallTrace] = Field(default_factory=list)
     iterations: int = 0
     total_tokens: int = 0

--- a/diagnostic_api/app/harness_tools/input_models.py
+++ b/diagnostic_api/app/harness_tools/input_models.py
@@ -11,7 +11,7 @@ never sees or passes it.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Literal, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -142,5 +142,290 @@ class ReadManualSectionInput(BaseModel):
         default=True,
         description=(
             "Include child subsections in the result."
+        ),
+    )
+
+
+# ── OBD investigation primitives (HARNESS-19) ────────────────────
+
+
+class ListSignalsInput(BaseModel):
+    """Input for the list_signals tool.
+
+    Discovery primitive — answers 'what signals does this OBD log
+    contain?' before any reading.  Cheap.
+    """
+
+    pattern: Optional[str] = Field(
+        default=None,
+        description=(
+            "Glob-style filter on signal name (case-insensitive). "
+            "Examples: '*TEMP*', 'A_YAM_*', 'RPM'. "
+            "Omit to list all signals."
+        ),
+    )
+    subsystem: Literal["engine", "abs", "all"] = Field(
+        default="all",
+        description=(
+            "Filter by ECU subsystem. 'engine' = K-Line engine "
+            "ECU (Channel A). 'abs' = CAN ABS ECU (Channel B). "
+            "Defaults to 'all'."
+        ),
+    )
+
+
+class ReadWindowInput(BaseModel):
+    """Input for the read_window tool.
+
+    Targeted sample read for one or more signals in a time window,
+    with auto-downsampling.  Medium token cost.
+    """
+
+    signals: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=8,
+        description=(
+            "Signal/column names to read (e.g. ['RPM', "
+            "'COOLANT_TEMP', 'A_YAM_INJ_MS']). 1-8 signals per "
+            "call. Use list_signals first to discover available "
+            "names."
+        ),
+    )
+    start_time: Optional[str] = Field(
+        default=None,
+        description=(
+            "Start of time window (ISO format, e.g. "
+            "'2026-05-08T11:21:30'). Omit to read from session "
+            "start."
+        ),
+    )
+    end_time: Optional[str] = Field(
+        default=None,
+        description=(
+            "End of time window (ISO format). Omit to read to "
+            "session end."
+        ),
+    )
+    max_rows: int = Field(
+        default=50,
+        ge=1,
+        le=500,
+        description=(
+            "Max sample rows to return. If the window has more "
+            "samples than this, the tool evenly downsamples. "
+            "Hard cap 500 (privacy boundary)."
+        ),
+    )
+
+
+_STATS_INCLUDE_T = Literal[
+    "basic", "percentiles", "trend", "extrema",
+]
+
+
+class GetSignalStatsInput(BaseModel):
+    """Input for the get_signal_stats tool.
+
+    Aggregate primitive — summary statistics without raw samples.
+    Cheap. Reuses obd_agent.statistics_extractor under the hood.
+    """
+
+    signals: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description=(
+            "Signal names to summarize (1-10 per call)."
+        ),
+    )
+    time_range: Optional[Tuple[str, str]] = Field(
+        default=None,
+        description=(
+            "Optional (start, end) ISO timestamps. Omit for "
+            "full session."
+        ),
+    )
+    include: Optional[List[_STATS_INCLUDE_T]] = Field(
+        default=None,
+        description=(
+            "Which stat groups to include. Choose from "
+            "'basic' (min/max/mean/std/count), "
+            "'percentiles' (p5/p25/p50/p75/p95), "
+            "'trend' (linreg_slope, autocorr_lag1), "
+            "'extrema' (timestamps of min and max). "
+            "Default: ['basic', 'percentiles']."
+        ),
+    )
+
+
+_EVENT_PREDICATE_T = Literal[
+    "above_threshold",
+    "below_threshold",
+    "rising_above",
+    "falling_below",
+    "rate_of_change_above",
+    "rate_of_change_below",
+    "missing",
+]
+
+
+class FindEventsInput(BaseModel):
+    """Input for the find_events tool.
+
+    Grep-of-time-series. Returns (start, end, peak) tuples for
+    windows where the predicate holds.  Cheap.
+    """
+
+    signal: str = Field(
+        ...,
+        description="Signal name to scan.",
+    )
+    predicate: _EVENT_PREDICATE_T = Field(
+        ...,
+        description=(
+            "Condition to find. "
+            "'above_threshold'/'below_threshold' require "
+            "threshold parameter. "
+            "'rising_above'/'falling_below' require threshold; "
+            "match only at crossings (first sample where signal "
+            "crosses from one side to the other). "
+            "'rate_of_change_above'/'rate_of_change_below' "
+            "require threshold and operate on finite differences "
+            "(value units per second). "
+            "'missing' finds N/A windows; threshold ignored."
+        ),
+    )
+    threshold: Optional[float] = Field(
+        default=None,
+        description=(
+            "Threshold value (required for all predicates "
+            "except 'missing')."
+        ),
+    )
+    min_duration_seconds: float = Field(
+        default=1.0,
+        ge=0.0,
+        description=(
+            "Drop events shorter than this. Useful for "
+            "filtering single-sample spikes."
+        ),
+    )
+    merge_gap_seconds: float = Field(
+        default=2.0,
+        ge=0.0,
+        description=(
+            "Merge adjacent events whose gap is below this "
+            "duration. 0 disables merging."
+        ),
+    )
+    time_range: Optional[Tuple[str, str]] = Field(
+        default=None,
+        description=(
+            "Optional (start, end) ISO timestamps. Omit for "
+            "full session."
+        ),
+    )
+    max_events: int = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description=(
+            "Max events to return (most recent if more match)."
+        ),
+    )
+
+
+class ListDTCsInput(BaseModel):
+    """Input for the list_dtcs tool.
+
+    Enumerates fault codes in the session. Surfaces standard
+    P/C/B/U codes and Yamaha-proprietary hex codes.  Cheap.
+    """
+
+    status: Literal["stored", "pending", "all"] = Field(
+        default="all",
+        description=(
+            "Filter by DTC status. 'stored' = confirmed faults, "
+            "'pending' = unconfirmed (not yet two-trip "
+            "validated)."
+        ),
+    )
+    ecu: Literal["engine", "abs", "all"] = Field(
+        default="all",
+        description=(
+            "Filter by originating ECU."
+        ),
+    )
+
+
+class LookupDTCInput(BaseModel):
+    """Input for the lookup_dtc tool.
+
+    Decodes one DTC to description + suspect subsystem + related
+    signals.  Falls back to manual-search guidance for codes
+    without a decoder.
+    """
+
+    code: str = Field(
+        ...,
+        min_length=2,
+        description=(
+            "DTC code. Standard format like 'P0117', or "
+            "Yamaha proprietary raw hex like "
+            "'87F11043000000000000CB'."
+        ),
+    )
+
+
+class DelegateToOBDAgentInput(BaseModel):
+    """Input for the delegate_to_obd_agent tool.
+
+    Hands an investigation inquiry off to the OBD sub-agent
+    (restricted to the 6 OBD primitives), receives back a
+    structured finding the main agent can quote.
+    """
+
+    inquiry: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description=(
+            "The investigation question to pose. Examples: "
+            "'Investigate stored DTCs and tell me what's normal "
+            "vs. abnormal.', 'What does the charging behaviour "
+            "look like across the trip?', 'Are there any "
+            "thermal anomalies in the coolant or cylinder head "
+            "temperature?'."
+        ),
+    )
+
+
+class DelegateToManualAgentInput(BaseModel):
+    """Input for the delegate_to_manual_agent tool.
+
+    Hands a manual-lookup inquiry to the manual sub-agent,
+    receives back a structured finding with cited sections.
+    """
+
+    inquiry: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description=(
+            "The lookup question to pose. Examples: "
+            "'What is the diagnostic procedure for DTC P0117 "
+            "on MWS-150-A?', 'What is the spark plug torque "
+            "specification?', 'How do I test the coolant "
+            "temperature sensor circuit?'."
+        ),
+    )
+    obd_context: Optional[str] = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "Optional OBD findings context to help the manual "
+            "agent disambiguate (e.g. observed DTCs, key signal "
+            "anomalies)."
         ),
     )

--- a/diagnostic_api/app/harness_tools/obd_dtcs.py
+++ b/diagnostic_api/app/harness_tools/obd_dtcs.py
@@ -1,0 +1,493 @@
+"""DTC-side OBD investigation primitives (HARNESS-19).
+
+Two tools:
+
+- ``list_dtcs``  — enumerate fault codes present in the session.
+- ``lookup_dtc`` — decode one code (standard or Yamaha-proprietary)
+  with manual-search pivot guidance.
+
+The Yamaha fixture stores DTCs in two distinct shapes that this
+module unifies:
+
+1. **Metadata header** (Yamaha CSV): ``# KL_Stored: 87F1...`` lines
+   in the ``#``-prefixed block — surfaced via
+   ``OBDLogData.metadata_dtcs``.
+2. **Column-level** (standard OBD-II TSV): ``GET_DTC`` and
+   ``GET_CURRENT_DTC`` columns with python-OBD's Python-literal
+   list format — parsed by ``obd_agent.log_parser._parse_dtc_list``.
+
+For Yamaha proprietary hex codes there is no decoder. Per the
+locked design decision (HARNESS-19), ``lookup_dtc`` returns honest
+"no decoder available" output with a ``search_manual`` pivot
+suggestion.
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import structlog
+
+from app.harness.tool_registry import ToolDefinition
+from app.harness_tools.input_models import (
+    ListDTCsInput,
+    LookupDTCInput,
+)
+from app.harness_tools.obd_loader import (
+    MetadataDTC,
+    OBDLogData,
+    load_for_session,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Standard P/C/B/U code helpers ────────────────────────────────
+
+
+_STANDARD_DTC_RE = re.compile(r"^[PCBU][0-9A-Fa-f]{4}$", re.IGNORECASE)
+_YAMAHA_HEX_RE = re.compile(r"^[0-9A-Fa-f]{8,}$")
+
+
+def _classify_code(code: str) -> str:
+    """Tag a DTC code by format family.
+
+    Returns one of ``"standard"`` (P/C/B/U + 4 hex digits, case
+    insensitive), ``"yamaha_hex"`` (raw Yamaha byte string,
+    10+ hex digits), or ``"unknown"``.
+    """
+    code = code.strip()
+    if _STANDARD_DTC_RE.match(code):
+        return "standard"
+    if _YAMAHA_HEX_RE.match(code) and len(code) >= 10:
+        return "yamaha_hex"
+    return "unknown"
+
+
+_DTC_SUBSYSTEM_MAP: Dict[str, str] = {
+    "P": "engine / powertrain",
+    "C": "chassis",
+    "B": "body",
+    "U": "network",
+}
+
+
+def _subsystem_from_letter(code: str) -> str:
+    """Map the first character of a standard DTC to a subsystem label."""
+    if not code:
+        return "unknown"
+    return _DTC_SUBSYSTEM_MAP.get(code[0].upper(), "unknown")
+
+
+def _load_standard_dtc_table():
+    """Try to load python-OBD's DTC description table.
+
+    Imports lazily so the module loads even when ``python-obd`` is
+    not in the active environment.
+
+    Returns:
+        Dict[code, description] or ``{}`` on failure.
+    """
+    try:
+        from obd.OBDCommand import OBDCommand  # noqa: F401
+        import obd
+        table = getattr(obd.commands, "GET_DTC", None)
+        if table is None:
+            return {}
+        decoder = getattr(table, "decode", None)
+        # python-OBD doesn't expose a public code dict; rely on the
+        # internal ``obd.UnitsAndScaling`` lookup if present.
+        return getattr(obd, "_DTC", {}) or {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+# Standard P-code related-PID hints.  Keep small and curated — the
+# agent can always fall back to search_manual for richer guidance.
+_RELATED_PIDS: Dict[str, List[str]] = {
+    "P0117": ["COOLANT_TEMP", "IAT", "CTRL_VOLT"],
+    "P0118": ["COOLANT_TEMP", "IAT", "CTRL_VOLT"],
+    "P0171": ["SHORT_FUEL_TRIM_1", "LONG_FUEL_TRIM_1", "MAP", "RPM"],
+    "P0174": ["SHORT_FUEL_TRIM_1", "LONG_FUEL_TRIM_1", "MAP", "RPM"],
+    "P0300": ["RPM", "ENGINE_LOAD", "TIMING_ADVANCE"],
+    "P0301": ["RPM", "ENGINE_LOAD"],
+    "P0302": ["RPM", "ENGINE_LOAD"],
+    "P0303": ["RPM", "ENGINE_LOAD"],
+    "P0304": ["RPM", "ENGINE_LOAD"],
+}
+
+
+# ── DTC collection from the session ──────────────────────────────
+
+
+def _column_dtcs(data: OBDLogData) -> List[Dict[str, Any]]:
+    """Pull standard P-code DTCs out of GET_DTC columns.
+
+    Uses ``obd_agent.log_parser._parse_dtc_list`` for parsing.  Both
+    ``GET_DTC`` (stored) and ``GET_CURRENT_DTC`` (pending) columns
+    are scanned.  Duplicate codes within the same column are
+    de-duplicated; presence in ``GET_DTC`` only marks the code as
+    stored, presence in ``GET_CURRENT_DTC`` only marks it as
+    pending — codes appearing in both are reported as ``stored``.
+
+    Args:
+        data: Parsed log.
+
+    Returns:
+        Ordered list of dicts with keys ``code``, ``status``,
+        ``ecu``, ``format``, ``description`` (if available).
+    """
+    from obd_agent.log_parser import _parse_dtc_list
+
+    stored: Dict[str, str] = {}
+    pending: Dict[str, str] = {}
+    for r in data.rows:
+        for cell, bucket in (
+            (r.get("GET_DTC", ""), stored),
+            (r.get("GET_CURRENT_DTC", ""), pending),
+        ):
+            for code, desc in _parse_dtc_list(cell):
+                key = code.upper()
+                bucket.setdefault(key, desc)
+
+    out: List[Dict[str, Any]] = []
+    for code, desc in stored.items():
+        out.append({
+            "code": code,
+            "status": "stored",
+            "ecu": "engine",
+            "format": _classify_code(code),
+            "description": desc or None,
+        })
+    for code, desc in pending.items():
+        if code in stored:
+            # Already reported as stored.
+            continue
+        out.append({
+            "code": code,
+            "status": "pending",
+            "ecu": "engine",
+            "format": _classify_code(code),
+            "description": desc or None,
+        })
+    return out
+
+
+def _metadata_to_dict(entry: MetadataDTC) -> Dict[str, Any]:
+    """Convert a ``MetadataDTC`` to the unified dict shape."""
+    return {
+        "code": entry.code,
+        "status": entry.status,
+        "ecu": entry.ecu,
+        "format": _classify_code(entry.code),
+        "description": None,
+    }
+
+
+def _collect_all_dtcs(data: OBDLogData) -> List[Dict[str, Any]]:
+    """Merge metadata-block and column-level DTCs.
+
+    Yamaha fixture: metadata block carries the raw hex codes.
+    Standard TSV: GET_DTC columns carry standard P-codes.
+    Both paths run; results are de-duplicated by ``(code, status)``.
+    """
+    seen: set = set()
+    out: List[Dict[str, Any]] = []
+    for entry in data.metadata_dtcs:
+        d = _metadata_to_dict(entry)
+        key = (d["code"], d["status"])
+        if key not in seen:
+            seen.add(key)
+            out.append(d)
+    for d in _column_dtcs(data):
+        key = (d["code"], d["status"])
+        if key not in seen:
+            seen.add(key)
+            out.append(d)
+    return out
+
+
+# ── list_dtcs ────────────────────────────────────────────────────
+
+
+def _ecu_filter_matches(entry: Dict[str, Any], wanted: str) -> bool:
+    """Coarse ECU filter — handles 'engine' vs 'abs' tagging."""
+    if wanted == "all":
+        return True
+    ecu = (entry.get("ecu") or "").lower()
+    if wanted == "engine":
+        return "k-line" in ecu or "engine" in ecu
+    if wanted == "abs":
+        return "can" in ecu or "abs" in ecu
+    return True
+
+
+async def list_dtcs(input_data: Dict[str, Any]) -> str:
+    """Enumerate DTCs in the session, optionally filtered.
+
+    Surfaces both Yamaha-hex metadata DTCs and standard-format
+    column-level DTCs.  Returns a grouped table.
+
+    Args:
+        input_data: ``ListDTCsInput`` + ``_session_id``.
+
+    Returns:
+        Text DTC inventory or an informational "no DTCs" message.
+    """
+    session_id = input_data["_session_id"]
+    status_filter = input_data.get("status", "all")
+    ecu_filter = input_data.get("ecu", "all")
+
+    data = load_for_session(session_id)
+    all_dtcs = _collect_all_dtcs(data)
+
+    # Apply filters.
+    filtered = [
+        d for d in all_dtcs
+        if (status_filter == "all" or d["status"] == status_filter)
+        and _ecu_filter_matches(d, ecu_filter)
+    ]
+
+    lines: List[str] = []
+    lines.append(
+        f"DTCs in session — {len(filtered)} of "
+        f"{len(all_dtcs)} match filters "
+        f"(status='{status_filter}', ecu='{ecu_filter}')"
+    )
+
+    if not filtered:
+        if not all_dtcs:
+            lines.append("")
+            lines.append(
+                "No DTCs found in this session. Engine is "
+                "either healthy or the recorder did not capture "
+                "the DTC scan."
+            )
+        else:
+            lines.append("")
+            lines.append(
+                "No DTCs match these filters. Try "
+                "status='all' or ecu='all'."
+            )
+        return "\n".join(lines)
+
+    lines.append("")
+    # Group standard vs Yamaha hex for readability.
+    standard = [d for d in filtered if d["format"] == "standard"]
+    yamaha = [d for d in filtered if d["format"] == "yamaha_hex"]
+    unknown = [d for d in filtered if d["format"] == "unknown"]
+
+    if standard:
+        lines.append("Standard OBD-II codes:")
+        for d in standard:
+            desc = d["description"] or "(no description in logger)"
+            lines.append(
+                f"  {d['status'].upper():8s} {d['ecu']:12s} "
+                f"{d['code']}   — {desc}"
+            )
+        lines.append("")
+
+    if yamaha:
+        lines.append("Yamaha-proprietary raw hex codes:")
+        for d in yamaha:
+            lines.append(
+                f"  {d['status'].upper():8s} {d['ecu']:12s} "
+                f"{d['code']}   [no decoder]"
+            )
+        lines.append("")
+
+    if unknown:
+        lines.append("Unrecognized format:")
+        for d in unknown:
+            lines.append(
+                f"  {d['status'].upper():8s} {d['ecu']:12s} "
+                f"{d['code']}"
+            )
+        lines.append("")
+
+    notes: List[str] = []
+    if yamaha:
+        notes.append(
+            "Yamaha hex codes — call `lookup_dtc(code)` for "
+            "decode attempts + manual-search guidance."
+        )
+    if not data.rows:
+        notes.append(
+            "Session has no row-level data — only metadata DTCs "
+            "are available."
+        )
+    if notes:
+        lines.append("Notes:")
+        for n in notes:
+            lines.append(f"  • {n}")
+
+    return "\n".join(lines).rstrip()
+
+
+# ── lookup_dtc ───────────────────────────────────────────────────
+
+
+def _standard_lookup(code: str) -> Tuple[Optional[str], List[str]]:
+    """Return (description, related_pids) for a standard DTC code.
+
+    Description lookup uses python-OBD's DTC table when reachable;
+    falls back to ``None``.  Related-PIDs uses the curated map in
+    this module.
+    """
+    table = _load_standard_dtc_table()
+    desc = table.get(code.upper()) if table else None
+    related = _RELATED_PIDS.get(code.upper(), [])
+    return desc, related
+
+
+def _format_standard_lookup(code: str) -> str:
+    """Render a structured lookup result for a standard P/C/B/U code."""
+    desc, related = _standard_lookup(code)
+    sub = _subsystem_from_letter(code)
+    lines: List[str] = []
+    lines.append(f"DTC {code.upper()} — standard OBD-II code")
+    lines.append("")
+    lines.append(
+        f"Subsystem: {sub}"
+    )
+    if desc:
+        lines.append(f"Description: {desc}")
+    else:
+        lines.append(
+            "Description: no description available in the "
+            "in-process DTC table. The code is recognised as "
+            "standard format; consult the vehicle's manual for "
+            "the manufacturer-specific definition."
+        )
+    if related:
+        lines.append(
+            f"Related signals to investigate: {', '.join(related)}"
+        )
+    lines.append("")
+    lines.append("Next step suggestions:")
+    lines.append(
+        f"  • `search_manual(query='{code}')` — pull the "
+        f"manufacturer's diagnostic procedure."
+    )
+    if related:
+        rel = ", ".join(f"'{p}'" for p in related[:3])
+        lines.append(
+            f"  • `get_signal_stats(signals=[{rel}])` — check "
+            f"the related signals' distributions."
+        )
+    return "\n".join(lines)
+
+
+def _format_yamaha_lookup(code: str) -> str:
+    """Render the honest no-decoder response for a Yamaha hex code."""
+    return "\n".join([
+        f"DTC {code.upper()} — Yamaha-proprietary raw hex",
+        "",
+        "No decoder available in this codebase. This is a "
+        "Yamaha K-Line stored-DTC byte sequence (likely contains "
+        "header bytes, code body, and checksum); standard "
+        "P/C/B/U lookup tables do not apply.",
+        "",
+        "Recommended next steps:",
+        f"  • `search_manual(query='{code}')` — try the raw "
+        f"hex string against the Yamaha service manual directly.",
+        "  • `search_manual(query='DTC table')` — find the "
+        "Yamaha DTC chart in the manual appendix and map this "
+        "code by structure.",
+        "  • `search_manual(query='fault code list')` — broader "
+        "lookup if the DTC chart isn't named that.",
+        "",
+        "Once you have the Yamaha-defined fault code, return to "
+        "the OBD data with `get_signal_stats` and `find_events` "
+        "on the implicated signals.",
+    ])
+
+
+def _format_unknown_lookup(code: str) -> str:
+    """Render the error response for an unrecognised code format."""
+    return (
+        f"DTC '{code}' is not a recognised OBD-II standard "
+        f"P/C/B/U code (4 hex digits) and does not match the "
+        f"Yamaha hex format (10+ hex digits). Verify the code "
+        f"with the user, or call `search_manual(query='{code}')` "
+        f"in case the manual defines a manufacturer-specific "
+        f"chart."
+    )
+
+
+async def lookup_dtc(input_data: Dict[str, Any]) -> str:
+    """Decode one DTC code.
+
+    Standard P/C/B/U codes get a structured response with subsystem
+    + description + related signals + next-step suggestions.
+    Yamaha proprietary hex codes get the honest no-decoder
+    response with manual-search pivot.  Unrecognised formats get
+    a verification prompt.
+
+    Args:
+        input_data: ``LookupDTCInput`` + (optional) ``_session_id``.
+
+    Returns:
+        Structured decode text.
+    """
+    code = (input_data.get("code") or "").strip()
+    if not code:
+        return (
+            "Validation error: `code` must be a non-empty "
+            "string."
+        )
+
+    cls = _classify_code(code)
+    if cls == "standard":
+        return _format_standard_lookup(code)
+    if cls == "yamaha_hex":
+        return _format_yamaha_lookup(code)
+    return _format_unknown_lookup(code)
+
+
+# ── ToolDefinition exports ───────────────────────────────────────
+
+
+_LIST_DTCS_DESC = (
+    "List fault codes (DTCs) present in this session's OBD log. "
+    "Surfaces both standard P/C/B/U codes (from GET_DTC columns) "
+    "and Yamaha-proprietary raw hex codes (from the log metadata "
+    "block). Returns a grouped table separated by status "
+    "(stored vs pending) and ECU. Cheap — call freely. Filter "
+    "by status ('stored'/'pending'/'all') and ecu ('engine'/"
+    "'abs'/'all')."
+)
+
+_LOOKUP_DTC_DESC = (
+    "Decode one fault code. Standard P/C/B/U codes return "
+    "subsystem + description + related signals to investigate. "
+    "Yamaha-proprietary raw hex codes return an honest "
+    "'no decoder available' message with `search_manual` "
+    "pivot guidance (no fabricated decodings). Use after "
+    "`list_dtcs` to drill into a specific code."
+)
+
+
+LIST_DTCS_DEF = ToolDefinition(
+    name="list_dtcs",
+    description=_LIST_DTCS_DESC,
+    input_schema=ListDTCsInput.model_json_schema(),
+    handler=list_dtcs,
+    input_model=ListDTCsInput,
+    is_read_only=True,
+    max_result_chars=10_000,
+)
+
+
+LOOKUP_DTC_DEF = ToolDefinition(
+    name="lookup_dtc",
+    description=_LOOKUP_DTC_DESC,
+    input_schema=LookupDTCInput.model_json_schema(),
+    handler=lookup_dtc,
+    input_model=LookupDTCInput,
+    is_read_only=True,
+    max_result_chars=8_000,
+)

--- a/diagnostic_api/app/harness_tools/obd_loader.py
+++ b/diagnostic_api/app/harness_tools/obd_loader.py
@@ -1,0 +1,483 @@
+"""Yamaha-aware raw OBD data loader for the agent toolset.
+
+The existing ``obd_agent.log_parser.parse_log_file`` expects tab-separated
+internal TSV format produced by the format normalizer.  That path drops
+``A_YAM_*`` Yamaha-proprietary columns (see ``format_normalizer.py``
+APP-53 note), which would defeat HARNESS-19's locked decision to expose
+those signals to the agent.
+
+This loader bypasses the normalizer and reads the raw uploaded bytes
+directly, returning all columns (canonical K-Line ``A_KL_*`` plus
+proprietary ``A_YAM_*``) so the new investigation tools can answer
+questions about the full signal inventory.
+
+Two formats are supported transparently:
+
+1. **Yamaha dual-channel CSV** — comma-separated rows with a ``#``-prefixed
+   metadata block.  Detected by a ``# Yamaha Dual`` marker in the first
+   few lines.  Metadata block parsed for DTCs and channel info.
+2. **Standard OBD TSV** — tab-separated rows with the multi-line header
+   produced by python-OBD loggers.  Delegated to
+   ``obd_agent.log_parser.parse_log_file``.
+
+The unified return type is ``OBDLogData`` — rows + signal column names +
+DTC entries pulled from metadata + format tag.
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Tuple
+
+import structlog
+
+from app.config import settings
+from app.db.session import SessionLocal
+from app.models_db import OBDAnalysisSession
+from obd_agent.log_parser import parse_log_file
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Public types ─────────────────────────────────────────────────
+
+
+OBDLogFormat = Literal["yamaha_dual", "standard_tsv", "unknown"]
+"""Detected raw-file format tag."""
+
+
+@dataclass(frozen=True)
+class MetadataDTC:
+    """One DTC entry pulled from a Yamaha metadata header.
+
+    Attributes:
+        code: Raw code string (Yamaha hex format).
+        status: ``"stored"`` or ``"pending"``.
+        ecu: Originating ECU label (e.g. ``"K-Line"``).
+    """
+
+    code: str
+    status: Literal["stored", "pending"]
+    ecu: str
+
+
+@dataclass
+class OBDLogData:
+    """Parsed OBD log with full column preservation.
+
+    Attributes:
+        format: Detected format tag.
+        rows: List of column-name → raw-string-value row dicts.
+            Empty list if the file has no data rows.
+        columns: Ordered column names from the header (including
+            ``A_YAM_*`` proprietary columns for Yamaha format).
+            Excludes the ``Timestamp`` column.
+        metadata_dtcs: DTC entries pulled from the ``#`` metadata
+            block (Yamaha format).  Empty list for other formats.
+        metadata_lines: Raw ``#``-prefixed metadata lines (Yamaha
+            format), preserved verbatim for downstream tools that
+            want to surface them.
+        channels_present: ECU channels that have data in this log
+            (e.g. ``{"engine"}``).  ``"engine"`` is set when any
+            ``A_KL_*`` or ``A_YAM_*`` column is present.
+            ``"abs"`` is set when CAN ABS columns are present
+            (none in the current fixture).
+    """
+
+    format: OBDLogFormat
+    rows: List[Dict[str, str]] = field(default_factory=list)
+    columns: List[str] = field(default_factory=list)
+    metadata_dtcs: List[MetadataDTC] = field(default_factory=list)
+    metadata_lines: List[str] = field(default_factory=list)
+    channels_present: set = field(default_factory=set)
+
+
+# ── File-path resolution ─────────────────────────────────────────
+
+
+def resolve_log_path(session_id: str) -> Path:
+    """Resolve the raw OBD log file path from a session UUID.
+
+    Looks up ``raw_input_file_path`` on the ``OBDAnalysisSession``
+    row and joins it with ``settings.obd_log_storage_path``.  Mirrors
+    the pattern used by the legacy ``read_obd_data`` tool so test
+    fixtures and production storage paths line up identically.
+
+    Args:
+        session_id: UUID string identifying the session.
+
+    Returns:
+        Absolute filesystem path to the raw log.
+
+    Raises:
+        ValueError: If the session_id is malformed, the row doesn't
+            exist, or the row has no recorded raw file path.
+    """
+    try:
+        sid = uuid.UUID(session_id)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(
+            f"Invalid session_id format: {session_id}"
+        ) from exc
+
+    db = SessionLocal()
+    try:
+        session = (
+            db.query(OBDAnalysisSession)
+            .filter(OBDAnalysisSession.id == sid)
+            .first()
+        )
+        if session is None:
+            raise ValueError(
+                f"Session not found: {session_id}"
+            )
+        raw_path = session.raw_input_file_path
+        if not raw_path:
+            raise ValueError(
+                f"Session {session_id} has no raw OBD log "
+                f"file on disk."
+            )
+        return Path(settings.obd_log_storage_path) / raw_path
+    finally:
+        db.close()
+
+
+# ── Format detection ─────────────────────────────────────────────
+
+
+_YAMAHA_DUAL_MARKERS = (
+    "yamaha dual",
+    "ch.a:",
+    "kl_ecu_name",
+)
+
+
+def detect_format(text: str) -> OBDLogFormat:
+    """Classify raw log content by format.
+
+    Reads the first ~60 lines and looks for distinguishing markers.
+    Doesn't open the file from a path so callers can detect from
+    in-memory content during tests.
+
+    Args:
+        text: Raw file content as a string.
+
+    Returns:
+        Format tag.  ``"unknown"`` if no marker fires.
+    """
+    head = "\n".join(text.splitlines()[:60]).lower()
+    if any(marker in head for marker in _YAMAHA_DUAL_MARKERS):
+        return "yamaha_dual"
+    # Standard OBD TSV uses "OBD Data Log" header (see log_parser).
+    if "obd data log" in head and "\t" in head:
+        return "standard_tsv"
+    # Tab-separated with Timestamp header — assume standard TSV.
+    for line in text.splitlines()[:30]:
+        if line.startswith("Timestamp\t"):
+            return "standard_tsv"
+    return "unknown"
+
+
+# ── Yamaha-dual parsing ──────────────────────────────────────────
+
+
+_DTC_METADATA_RE = re.compile(
+    r"^#\s*(?P<channel>[A-Za-z]+)_(?P<status>Stored|Pending)\s*:\s*"
+    r"(?P<code>[0-9A-Fa-fxX]{4,})\s*$",
+)
+_CHANNEL_LABEL = {
+    "kl": "K-Line",
+    "can": "CAN",
+}
+
+
+def _parse_yamaha_metadata_dtcs(
+    metadata_lines: List[str],
+) -> List[MetadataDTC]:
+    """Extract DTC entries from a Yamaha-format metadata block.
+
+    The fixture format puts DTCs in lines like::
+
+        # DTCs:
+        #   KL_Stored: 87F11043000000000000CB
+        #   KL_Pending: 87F11047000000000000CF
+
+    Args:
+        metadata_lines: Raw ``#``-prefixed lines from the header.
+
+    Returns:
+        Ordered list of parsed DTCs (stored first, pending second,
+        in file order).
+    """
+    out: List[MetadataDTC] = []
+    for raw in metadata_lines:
+        match = _DTC_METADATA_RE.match(raw.strip())
+        if not match:
+            continue
+        channel = match.group("channel").lower()
+        ecu_label = _CHANNEL_LABEL.get(channel, channel.upper())
+        status = match.group("status").lower()  # "stored" or "pending"
+        code = match.group("code").upper()
+        out.append(MetadataDTC(
+            code=code,
+            status=status,  # type: ignore[arg-type]
+            ecu=ecu_label,
+        ))
+    return out
+
+
+def _parse_yamaha_dual_csv(text: str) -> OBDLogData:
+    """Parse a Yamaha dual-channel CSV file into ``OBDLogData``.
+
+    Splits metadata (``#``-prefixed lines) from data, reads CSV with
+    the stdlib reader (handles quoted fields, embedded commas, etc.),
+    and preserves all columns including ``A_YAM_*`` proprietary
+    fields.
+
+    Args:
+        text: Full file content.
+
+    Returns:
+        Parsed ``OBDLogData`` with format=``"yamaha_dual"``.
+
+    Raises:
+        ValueError: If no header row is present.
+    """
+    metadata_lines: List[str] = []
+    data_lines: List[str] = []
+    for raw in text.splitlines():
+        if raw.startswith("#"):
+            metadata_lines.append(raw)
+            continue
+        # Drop the unicode "═" separator line if present.
+        if raw and raw[0] not in (",", "\t") and "═" in raw:
+            continue
+        if not raw:
+            continue
+        data_lines.append(raw)
+
+    if not data_lines:
+        raise ValueError(
+            "Yamaha dual-channel CSV has no data rows."
+        )
+
+    reader = csv.reader(io.StringIO("\n".join(data_lines)))
+    rows_iter = iter(reader)
+    try:
+        raw_headers = next(rows_iter)
+    except StopIteration as exc:
+        raise ValueError(
+            "Yamaha dual-channel CSV missing header row."
+        ) from exc
+
+    headers = [h.strip() for h in raw_headers]
+    if "Timestamp" not in headers:
+        raise ValueError(
+            "Yamaha dual-channel CSV header is missing the "
+            "Timestamp column."
+        )
+
+    rows: List[Dict[str, str]] = []
+    for raw_row in rows_iter:
+        if not raw_row or all(c.strip() == "" for c in raw_row):
+            continue
+        row: Dict[str, str] = {}
+        for i, h in enumerate(headers):
+            val = raw_row[i].strip() if i < len(raw_row) else ""
+            row[h] = val
+        rows.append(row)
+
+    metadata_dtcs = _parse_yamaha_metadata_dtcs(metadata_lines)
+
+    channels: set = set()
+    if any(h.startswith(("A_KL_", "A_YAM_")) for h in headers):
+        channels.add("engine")
+    if any(h.startswith("B_") for h in headers):
+        channels.add("abs")
+
+    # Strip Timestamp from columns inventory — it is implicit and
+    # tools list signal columns only.
+    signal_cols = [h for h in headers if h != "Timestamp"]
+
+    return OBDLogData(
+        format="yamaha_dual",
+        rows=rows,
+        columns=signal_cols,
+        metadata_dtcs=metadata_dtcs,
+        metadata_lines=metadata_lines,
+        channels_present=channels,
+    )
+
+
+# ── Standard TSV adapter ─────────────────────────────────────────
+
+
+def _parse_standard_tsv(path: Path, text: str) -> OBDLogData:
+    """Parse a standard OBD TSV via the existing log_parser path.
+
+    Delegates row parsing to ``parse_log_file()`` then derives the
+    column inventory from the first row's keys.  No metadata DTCs
+    (standard format puts DTCs inside ``GET_DTC`` / ``GET_CURRENT_DTC``
+    columns, surfaced separately by ``obd_dtcs.list_dtcs``).
+
+    Args:
+        path: File path (passed through to ``parse_log_file``).
+        text: File content (used only for channel detection).
+
+    Returns:
+        Parsed ``OBDLogData`` with format=``"standard_tsv"``.
+    """
+    rows = parse_log_file(path)
+    columns: List[str] = []
+    if rows:
+        columns = [c for c in rows[0].keys() if c != "Timestamp"]
+    channels: set = set()
+    if rows:
+        channels.add("engine")
+    return OBDLogData(
+        format="standard_tsv",
+        rows=rows,
+        columns=columns,
+        metadata_dtcs=[],
+        metadata_lines=[],
+        channels_present=channels,
+    )
+
+
+# ── Public entry point ───────────────────────────────────────────
+
+
+def load_obd_data(path: Path) -> OBDLogData:
+    """Load raw OBD data from disk, preserving all columns.
+
+    Detects the file format and dispatches to the appropriate
+    parser.  Always returns the full column inventory so the agent
+    toolset can expose ``A_YAM_*`` proprietary signals (HARNESS-19
+    locked decision).
+
+    Args:
+        path: Absolute path to the raw log file.
+
+    Returns:
+        ``OBDLogData`` with rows, columns, and (for Yamaha format)
+        metadata DTCs.
+
+    Raises:
+        FileNotFoundError: If ``path`` doesn't exist.
+        ValueError: If the file format cannot be parsed.
+    """
+    if not path.exists():
+        raise FileNotFoundError(
+            f"OBD log file not found: {path}"
+        )
+    text = path.read_text(encoding="utf-8", errors="replace")
+    # Defensive BOM strip — the Yamaha fixture is UTF-8 with BOM
+    # and ``read_text(encoding="utf-8")`` does not consume it.
+    # Without this the first metadata line leaks into the CSV
+    # body and the header parser fails.
+    if text.startswith("﻿"):
+        text = text[1:]
+    fmt = detect_format(text)
+    if fmt == "yamaha_dual":
+        return _parse_yamaha_dual_csv(text)
+    if fmt == "standard_tsv":
+        return _parse_standard_tsv(path, text)
+    # Unknown format: try standard TSV (most-common upload shape)
+    # and if it fails, fall back to Yamaha CSV.  This ordering keeps
+    # the happy path fast for standard logs.
+    try:
+        return _parse_standard_tsv(path, text)
+    except Exception:  # noqa: BLE001
+        return _parse_yamaha_dual_csv(text)
+
+
+def load_for_session(session_id: str) -> OBDLogData:
+    """Resolve a session's raw file path and load it.
+
+    Convenience wrapper combining ``resolve_log_path`` and
+    ``load_obd_data`` for tools that operate on a session UUID.
+
+    Args:
+        session_id: OBD analysis session UUID string.
+
+    Returns:
+        Parsed ``OBDLogData``.
+
+    Raises:
+        ValueError: From ``resolve_log_path`` on missing session.
+        FileNotFoundError: If the file path resolves but the file
+            is missing on disk.
+    """
+    path = resolve_log_path(session_id)
+    return load_obd_data(path)
+
+
+# ── Time helpers shared across OBD tools ─────────────────────────
+
+
+_TIMESTAMP_FORMATS = (
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def parse_timestamp(raw: str):
+    """Parse an OBD timestamp string to a naive datetime.
+
+    Tolerates the fixture's millisecond-suffix format
+    (``2026-05-08 11:20:40.508``) and the standard-TSV
+    second-precision format.  Returns ``None`` on failure so
+    callers can skip bad rows without raising.
+
+    Args:
+        raw: Timestamp string from a row dict.
+
+    Returns:
+        Parsed ``datetime`` or ``None``.
+    """
+    from datetime import datetime
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    for fmt in _TIMESTAMP_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    # Last attempt: ISO 8601 parser.
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def try_float(raw: str) -> Optional[float]:
+    """Parse a numeric cell, returning None on N/A or failure.
+
+    Treats common missing-value tokens (``"N/A"``, empty string,
+    ``"nan"``) as missing without surfacing an error.
+
+    Args:
+        raw: Raw cell string.
+
+    Returns:
+        Parsed float or ``None``.
+    """
+    if raw is None:
+        return None
+    s = raw.strip()
+    if not s or s.upper() == "N/A" or s.lower() == "nan":
+        return None
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None

--- a/diagnostic_api/app/harness_tools/obd_signal_inventory.py
+++ b/diagnostic_api/app/harness_tools/obd_signal_inventory.py
@@ -1,0 +1,335 @@
+"""Signal inventory + classification for the OBD investigation tools.
+
+Builds a typed view of the columns present in a parsed ``OBDLogData``
+so the agent tools (``list_signals``, ``read_window``,
+``get_signal_stats``, ``find_events``) can reason about which signals
+are dense vs sparse, which ECU they came from, and what units they
+carry.
+
+Units for ``A_KL_*`` and ``A_YAM_*`` columns come from a hand-curated
+map below (HARNESS-19 locked decision: expose Yamaha proprietary
+columns under their original names, with best-effort unit annotations
+where we know them).
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Dict, List, Literal, Optional
+
+from app.harness_tools.obd_loader import OBDLogData, try_float
+
+
+Subsystem = Literal["engine", "abs", "other"]
+"""Subsystem tag for a single signal."""
+
+
+# ── Curated unit map ─────────────────────────────────────────────
+
+
+_YAMAHA_UNITS: Dict[str, str] = {
+    # K-Line canonical PIDs (Channel A, engine ECU)
+    "A_KL_RPM": "rpm",
+    "A_KL_SPEED": "km/h",
+    "A_KL_COOLANT_TEMP": "°C",
+    "A_KL_IAT": "°C",
+    "A_KL_MAP": "kPa",
+    "A_KL_BARO": "kPa",
+    "A_KL_TIMING_ADV": "deg",
+    "A_KL_TPS": "%",
+    "A_KL_REL_TPS": "%",
+    "A_KL_ENGINE_LOAD": "%",
+    "A_KL_CTRL_VOLT": "V",
+    # Yamaha proprietary confirmed
+    "A_YAM_BARO_REF": "kPa",
+    "A_YAM_BATT_V": "V",
+    "A_YAM_CHT": "°C",
+    "A_YAM_ECT": "°C",
+    "A_YAM_IAT": "°C",
+    "A_YAM_IGN": "deg",
+    "A_YAM_INJ_MS": "ms",
+    "A_YAM_INJ_US": "us",
+    "A_YAM_ISC": "step",
+    "A_YAM_RPM": "rpm",
+    "A_YAM_VVA": "deg",
+    # Yamaha proprietary provisional (raw bytes — unit unknown)
+    "A_YAM_BATT_RAW": "raw",
+    "A_YAM_MAP_RAW": "raw",
+    "A_YAM_O2_FB_RAW": "raw",
+    "A_YAM_TPS_RAW": "raw",
+}
+"""Curated unit annotations for Yamaha-format columns.
+
+For standard-OBD-TSV columns we fall back to the unit map in
+``obd_agent.log_parser._PID_UNITS``.
+"""
+
+
+def _standard_unit(col: str) -> Optional[str]:
+    """Look up the unit for a standard OBD-II PID column.
+
+    Imports lazily to avoid a top-level circular dependency with
+    ``obd_agent``.
+    """
+    from obd_agent.log_parser import _PID_UNITS
+    return _PID_UNITS.get(col)
+
+
+# ── Signal descriptor ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SignalDescriptor:
+    """Typed view of one column in an OBD log.
+
+    Attributes:
+        name: Column name as it appears in the file (e.g. ``RPM``
+            or ``A_YAM_INJ_MS``).
+        units: Engineering units string when known, else
+            ``"unknown"``.  ``"raw"`` for Yamaha provisional bytes.
+        subsystem: ECU subsystem tag.
+        density: Fraction of rows with a parseable numeric value.
+            ``0.0`` means the column is all N/A.
+        valid_count: Absolute count of parseable numeric samples.
+        total_count: Total row count.
+    """
+
+    name: str
+    units: str
+    subsystem: Subsystem
+    density: float
+    valid_count: int
+    total_count: int
+
+    @property
+    def density_label(self) -> str:
+        """Coarse density label for human-friendly output."""
+        if self.density >= 0.99:
+            return "dense"
+        if self.density >= 0.5:
+            return f"sparse ({int(self.density * 100)}%)"
+        if self.density > 0:
+            return f"very sparse ({int(self.density * 100)}%)"
+        return "all N/A"
+
+
+# ── Classification + inventory build ─────────────────────────────
+
+
+_STANDARD_PID_NAMES = frozenset({
+    "RPM", "SPEED", "COOLANT_TEMP", "INTAKE_TEMP", "IAT",
+    "MAP", "BARO", "BAROMETRIC_PRESSURE",
+    "ENGINE_LOAD", "ABSOLUTE_LOAD",
+    "THROTTLE_POS", "THROTTLE_POS_B", "RELATIVE_THROTTLE_POS",
+    "TIMING_ADVANCE", "MAF", "FUEL_RAIL_PRESSURE_DIRECT",
+    "SHORT_FUEL_TRIM_1", "LONG_FUEL_TRIM_1",
+    "O2_B1S2", "O2_S1_WR_CURRENT",
+    "CONTROL_MODULE_VOLTAGE", "ELM_VOLTAGE",
+    "ACCELERATOR_POS_D", "ACCELERATOR_POS_E",
+    "RUN_TIME", "DISTANCE_W_MIL", "DISTANCE_SINCE_DTC_CLEAR",
+    "COMMANDED_EQUIV_RATIO",
+})
+"""Known standard OBD-II PID column names (no prefix).
+
+Used by ``classify_subsystem`` to recognise pre-normalised
+columns (RPM, COOLANT_TEMP, etc.) as engine signals.
+"""
+
+
+def classify_subsystem(col: str) -> Subsystem:
+    """Tag a column with its originating ECU subsystem.
+
+    Heuristic based on the Yamaha-dual prefix convention
+    (``A_*`` = Channel A engine, ``B_*`` = Channel B ABS) plus
+    a curated list of standard OBD-II PID names that have no
+    prefix and represent engine signals.
+
+    Args:
+        col: Column name.
+
+    Returns:
+        Subsystem tag.
+    """
+    if col.startswith("A_KL_") or col.startswith("A_YAM_"):
+        return "engine"
+    if col.startswith("B_"):
+        return "abs"
+    if col.upper() in _STANDARD_PID_NAMES:
+        return "engine"
+    return "other"
+
+
+def units_for(col: str) -> str:
+    """Resolve the engineering unit for a column.
+
+    Order of lookup:
+    1. Yamaha-format curated map.
+    2. Standard OBD-II ``_PID_UNITS`` map (via lazy import).
+    3. Fallback ``"unknown"``.
+    """
+    if col in _YAMAHA_UNITS:
+        return _YAMAHA_UNITS[col]
+    std = _standard_unit(col)
+    if std is not None:
+        return std
+    return "unknown"
+
+
+def _density(rows: List[Dict[str, str]], col: str) -> tuple:
+    """Compute (valid_count, total_count) for a column.
+
+    ``valid_count`` counts cells parseable as float (per
+    ``try_float`` — treats ``N/A`` as missing).
+    """
+    total = len(rows)
+    if total == 0:
+        return 0, 0
+    valid = sum(
+        1 for r in rows if try_float(r.get(col, "")) is not None
+    )
+    return valid, total
+
+
+def build_inventory(
+    data: OBDLogData,
+) -> List[SignalDescriptor]:
+    """Build a ``SignalDescriptor`` list for every signal column.
+
+    ``Timestamp`` and any all-zero-length string columns are
+    excluded.  Density is computed by scanning the rows once per
+    column — O(rows * cols) but the fixture is small.
+
+    Args:
+        data: Parsed log.
+
+    Returns:
+        Ordered list of descriptors matching ``data.columns``.
+    """
+    out: List[SignalDescriptor] = []
+    for col in data.columns:
+        valid, total = _density(data.rows, col)
+        density = (valid / total) if total else 0.0
+        out.append(SignalDescriptor(
+            name=col,
+            units=units_for(col),
+            subsystem=classify_subsystem(col),
+            density=density,
+            valid_count=valid,
+            total_count=total,
+        ))
+    return out
+
+
+# ── Lookup helpers used by the signal tools ──────────────────────
+
+
+def filter_inventory(
+    inventory: List[SignalDescriptor],
+    pattern: Optional[str],
+    subsystem: Literal["engine", "abs", "all"],
+) -> List[SignalDescriptor]:
+    """Filter an inventory by glob pattern and subsystem.
+
+    Pattern matching is case-insensitive against the column name.
+    Use shell-style globs (``*TEMP*``, ``A_YAM_*``, ``RPM``).
+
+    Args:
+        inventory: Full inventory from ``build_inventory``.
+        pattern: Optional glob pattern.
+        subsystem: Subsystem filter (``"all"`` = no filter).
+
+    Returns:
+        Filtered list.
+    """
+    out = list(inventory)
+    if subsystem != "all":
+        out = [d for d in out if d.subsystem == subsystem]
+    if pattern:
+        pat = pattern.lower()
+        out = [
+            d for d in out
+            if fnmatch.fnmatchcase(d.name.lower(), pat)
+        ]
+    return out
+
+
+def resolve_signal_name(
+    name: str,
+    inventory: List[SignalDescriptor],
+) -> Optional[str]:
+    """Resolve a user-supplied signal name to a canonical column.
+
+    Matching strategy:
+    1. Exact match against an inventory column name.
+    2. Case-insensitive match.
+    3. Suffix match — useful when the LLM passes ``RPM`` and the
+       column is ``A_YAM_RPM``.  Returns the shortest matching
+       column name to bias toward canonical ``A_KL_`` columns over
+       proprietary ``A_YAM_`` ones.
+
+    Args:
+        name: Caller-supplied signal name.
+        inventory: Full inventory.
+
+    Returns:
+        Canonical column name or ``None`` if no match.
+    """
+    if not name:
+        return None
+    names = [d.name for d in inventory]
+    if name in names:
+        return name
+    upper = name.upper()
+    for col in names:
+        if col.upper() == upper:
+            return col
+    # Suffix match — prefer shortest (canonical K-Line over Yamaha
+    # proprietary when both are present).
+    candidates = [c for c in names if c.upper().endswith(upper)]
+    if candidates:
+        return min(candidates, key=len)
+    return None
+
+
+def fuzzy_suggestions(
+    name: str,
+    inventory: List[SignalDescriptor],
+    max_suggestions: int = 3,
+) -> List[str]:
+    """Suggest close-match signal names for an unknown input.
+
+    Cheap substring + edit-distance hybrid — returns names that
+    share a common substring with the input, ranked by length
+    proximity to the query.  Falls back to first-N inventory
+    columns if nothing matches.
+
+    Args:
+        name: Unknown signal name from the caller.
+        inventory: Full inventory.
+        max_suggestions: Maximum suggestions to return.
+
+    Returns:
+        Up to ``max_suggestions`` candidate column names.
+    """
+    if not inventory:
+        return []
+    query = (name or "").lower()
+    scored: List[tuple] = []
+    for d in inventory:
+        col_lower = d.name.lower()
+        # Substring hit gets best score.
+        if query and query in col_lower:
+            scored.append((0, d.name))
+            continue
+        # Otherwise score by shared characters.
+        shared = len(set(col_lower) & set(query))
+        if shared:
+            scored.append((10 - shared, d.name))
+    scored.sort(key=lambda t: (t[0], len(t[1])))
+    suggestions = [name for _, name in scored[:max_suggestions]]
+    if suggestions:
+        return suggestions
+    return [d.name for d in inventory[:max_suggestions]]

--- a/diagnostic_api/app/harness_tools/obd_signals.py
+++ b/diagnostic_api/app/harness_tools/obd_signals.py
@@ -1,0 +1,948 @@
+"""OBD investigation primitives — signal-side tools (HARNESS-19).
+
+Four cognitive primitives the agent uses to interrogate the raw OBD
+log without seeing it all at once:
+
+- ``list_signals``  — Glob analog. Discovery.
+- ``read_window``   — Read analog. Bounded windowed sample read.
+- ``get_signal_stats`` — Aggregate primitive. Summary without rows.
+- ``find_events``   — Grep analog. Where does signal meet predicate?
+
+All tools return plain text. Each one tolerates per-tool quirks of
+the Yamaha fixture (sparse first row, ``A_YAM_*`` proprietary
+columns, comma-separated CSV).
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import structlog
+
+from app.harness.tool_registry import ToolDefinition
+from app.harness_tools.input_models import (
+    FindEventsInput,
+    GetSignalStatsInput,
+    ListSignalsInput,
+    ReadWindowInput,
+)
+from app.harness_tools.obd_loader import (
+    OBDLogData,
+    load_for_session,
+    parse_timestamp,
+    try_float,
+)
+from app.harness_tools.obd_signal_inventory import (
+    SignalDescriptor,
+    build_inventory,
+    filter_inventory,
+    fuzzy_suggestions,
+    resolve_signal_name,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Shared helpers ───────────────────────────────────────────────
+
+
+def _format_duration(seconds: float) -> str:
+    """Render a duration in compact ``Xm Ys`` form."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    mins = int(seconds // 60)
+    secs = int(seconds % 60)
+    return f"{mins}m {secs}s"
+
+
+def _session_time_range(
+    rows: List[Dict[str, str]],
+) -> Tuple[Optional[datetime], Optional[datetime]]:
+    """Find the (first, last) valid timestamps in row order."""
+    first: Optional[datetime] = None
+    last: Optional[datetime] = None
+    for row in rows:
+        ts = parse_timestamp(row.get("Timestamp", ""))
+        if ts is None:
+            continue
+        if first is None:
+            first = ts
+        last = ts
+    return first, last
+
+
+def _filter_rows_by_time(
+    rows: List[Dict[str, str]],
+    start: Optional[datetime],
+    end: Optional[datetime],
+) -> List[Dict[str, str]]:
+    """Return rows whose timestamp is in ``[start, end]`` inclusive."""
+    out: List[Dict[str, str]] = []
+    for row in rows:
+        ts = parse_timestamp(row.get("Timestamp", ""))
+        if ts is None:
+            continue
+        if start is not None and ts < start:
+            continue
+        if end is not None and ts > end:
+            continue
+        out.append(row)
+    return out
+
+
+def _parse_window_bound(raw: Optional[str]):
+    """Parse an ISO timestamp window bound, returning None on bad input."""
+    if not raw:
+        return None
+    return parse_timestamp(raw)
+
+
+def _unknown_signal_message(
+    name: str,
+    inventory: List[SignalDescriptor],
+) -> str:
+    """Compose an actionable T2 error for an unrecognized signal."""
+    suggestions = fuzzy_suggestions(name, inventory)
+    if suggestions:
+        sug = ", ".join(suggestions)
+        return (
+            f"Signal '{name}' not in this session. "
+            f"Did you mean: {sug}? "
+            f"Use `list_signals` to see all "
+            f"{len(inventory)} available signals."
+        )
+    return (
+        f"Signal '{name}' not in this session and no close "
+        f"matches found. Use `list_signals` to see all "
+        f"{len(inventory)} available signals."
+    )
+
+
+def _ensure_data(session_id: str) -> Tuple[OBDLogData, List[SignalDescriptor]]:
+    """Load + build inventory for a session in one call."""
+    data = load_for_session(session_id)
+    inventory = build_inventory(data)
+    return data, inventory
+
+
+# ── list_signals ─────────────────────────────────────────────────
+
+
+async def list_signals(input_data: Dict[str, Any]) -> str:
+    """Enumerate signals available in the session, with filters.
+
+    Returns time range, sampling rate (best-effort), channel
+    presence, and per-signal name + units + density.  No samples
+    returned.
+
+    Args:
+        input_data: Validated ``ListSignalsInput`` fields plus the
+            loop-injected ``_session_id``.
+
+    Returns:
+        Text inventory.
+    """
+    session_id = input_data["_session_id"]
+    pattern = input_data.get("pattern")
+    subsystem = input_data.get("subsystem", "all")
+
+    data, inventory = _ensure_data(session_id)
+    rows = data.rows
+
+    first, last = _session_time_range(rows)
+    duration = (
+        (last - first).total_seconds()
+        if first and last else None
+    )
+    interval_hz = (
+        (len(rows) - 1) / duration
+        if duration and duration > 0 else None
+    )
+
+    lines: List[str] = []
+    lines.append(
+        f"Session has {len(rows)} samples in format "
+        f"'{data.format}'."
+    )
+    if first and last:
+        lines.append(
+            f"Time range: {first.isoformat()} → "
+            f"{last.isoformat()} "
+            f"({_format_duration(duration or 0)}"
+            + (f", ~{interval_hz:.2f} Hz" if interval_hz else "")
+            + ")"
+        )
+
+    # Channel presence
+    eng = "present" if "engine" in data.channels_present else "not present"
+    abs_state = "present" if "abs" in data.channels_present else "not present"
+    lines.append("Channels:")
+    lines.append(f"  Engine ECU (K-Line / Channel A): {eng}")
+    lines.append(f"  ABS ECU    (CAN / Channel B):    {abs_state}")
+
+    # Filter inventory
+    filtered = filter_inventory(inventory, pattern, subsystem)
+
+    lines.append("")
+    if pattern or subsystem != "all":
+        active_filters = []
+        if pattern:
+            active_filters.append(f"pattern='{pattern}'")
+        if subsystem != "all":
+            active_filters.append(f"subsystem='{subsystem}'")
+        lines.append(
+            f"Signals ({len(filtered)} match "
+            f"{' + '.join(active_filters)} "
+            f"of {len(inventory)} total):"
+        )
+    else:
+        lines.append(f"Signals ({len(filtered)} total):")
+
+    if not filtered:
+        lines.append(
+            "  (no signals match the filter)"
+        )
+    else:
+        # Column-align name and units
+        max_name = max(len(d.name) for d in filtered)
+        max_unit = max(len(d.units) for d in filtered)
+        for d in filtered:
+            lines.append(
+                f"  {d.name.ljust(max_name)}  "
+                f"{d.units.ljust(max_unit)}  "
+                f"{d.density_label}"
+            )
+
+    return "\n".join(lines)
+
+
+# ── read_window ──────────────────────────────────────────────────
+
+
+def _format_value(raw: str) -> str:
+    """Render a cell as ``f"{x:.2f}"`` when numeric, else echo."""
+    f = try_float(raw)
+    if f is None:
+        return "(N/A)"
+    return f"{f:.2f}"
+
+
+async def read_window(input_data: Dict[str, Any]) -> str:
+    """Read samples for one or more signals in a time window.
+
+    Auto-downsamples to ``max_rows`` by even spacing when the window
+    has more samples.  Always preserves the first and last row of
+    the window so the agent sees boundary behavior.
+
+    Args:
+        input_data: Validated ``ReadWindowInput`` + injected
+            ``_session_id``.
+
+    Returns:
+        Tabular text or an actionable error string.
+    """
+    session_id = input_data["_session_id"]
+    requested_signals: List[str] = input_data["signals"]
+    start_raw: Optional[str] = input_data.get("start_time")
+    end_raw: Optional[str] = input_data.get("end_time")
+    max_rows: int = int(input_data.get("max_rows", 50))
+
+    data, inventory = _ensure_data(session_id)
+
+    # Validate / resolve signal names.
+    resolved: List[str] = []
+    unknown: List[str] = []
+    for s in requested_signals:
+        canon = resolve_signal_name(s, inventory)
+        if canon is None:
+            unknown.append(s)
+        else:
+            resolved.append(canon)
+
+    if not resolved:
+        return _unknown_signal_message(
+            unknown[0] if unknown else "",
+            inventory,
+        )
+
+    # Parse window bounds.
+    start = _parse_window_bound(start_raw)
+    end = _parse_window_bound(end_raw)
+    if start is not None and end is not None and start > end:
+        return (
+            "Invalid time window: start_time must precede "
+            "end_time. Got "
+            f"start='{start_raw}', end='{end_raw}'."
+        )
+
+    first, last = _session_time_range(data.rows)
+    if start is not None and last is not None and start > last:
+        return (
+            f"Requested start_time '{start_raw}' is after the "
+            f"session end ({last.isoformat()}). Window has 0 "
+            f"samples."
+        )
+    if end is not None and first is not None and end < first:
+        return (
+            f"Requested end_time '{end_raw}' is before the "
+            f"session start ({first.isoformat()}). Window has "
+            f"0 samples."
+        )
+
+    windowed = _filter_rows_by_time(data.rows, start, end)
+    total = len(windowed)
+
+    if total == 0:
+        return (
+            f"Window has 0 samples. Session spans "
+            f"{first.isoformat() if first else '?'} → "
+            f"{last.isoformat() if last else '?'}. "
+            f"Adjust start_time/end_time or omit them."
+        )
+
+    # Downsample evenly.
+    truncated = total > max_rows
+    if truncated:
+        # Always include first + last; evenly sample the middle.
+        step = total / max_rows
+        keep_indices = sorted({
+            min(int(i * step), total - 1)
+            for i in range(max_rows)
+        } | {0, total - 1})
+        rows_out = [windowed[i] for i in keep_indices]
+    else:
+        rows_out = windowed
+
+    # Build table.
+    header = ["Timestamp"] + resolved
+    lines: List[str] = []
+    lines.append(
+        f"Signal window — {', '.join(resolved)}"
+    )
+    if first and last:
+        win_first = parse_timestamp(rows_out[0].get("Timestamp", ""))
+        win_last = parse_timestamp(rows_out[-1].get("Timestamp", ""))
+        if win_first and win_last:
+            lines.append(
+                f"Window:  {win_first.isoformat()} → "
+                f"{win_last.isoformat()} "
+                f"({_format_duration((win_last - win_first).total_seconds())}, "
+                f"{len(rows_out)} of {total} samples"
+                + (" [downsampled]" if truncated else "")
+                + ")"
+            )
+    lines.append("")
+
+    # Units row.
+    unit_lookup = {d.name: d.units for d in inventory}
+    unit_row = ["units"] + [
+        unit_lookup.get(s, "?") for s in resolved
+    ]
+    lines.append("\t".join(header))
+    lines.append("\t".join(unit_row))
+    for r in rows_out:
+        cells = [r.get("Timestamp", "")] + [
+            _format_value(r.get(s, "")) for s in resolved
+        ]
+        lines.append("\t".join(cells))
+
+    notes: List[str] = []
+    if unknown:
+        notes.append(
+            f"Ignored unrecognized signals: {unknown}"
+        )
+    if truncated:
+        notes.append(
+            f"Auto-downsampled — set max_rows higher or narrow "
+            f"the time range for full resolution."
+        )
+    # Missing-data per signal.
+    missing_notes: List[str] = []
+    for s in resolved:
+        miss = sum(
+            1 for r in rows_out
+            if try_float(r.get(s, "")) is None
+        )
+        if miss:
+            missing_notes.append(f"{s}: {miss}/{len(rows_out)} N/A")
+    if missing_notes:
+        notes.append("Missing samples — " + "; ".join(missing_notes))
+
+    if notes:
+        lines.append("")
+        lines.append("Notes: " + " | ".join(notes))
+
+    return "\n".join(lines)
+
+
+# ── get_signal_stats ─────────────────────────────────────────────
+
+
+def _percentile(sorted_vals: List[float], p: float) -> float:
+    """Inclusive linear-interpolation percentile.
+
+    Mirrors numpy's default (``linear`` method).  Assumes
+    ``sorted_vals`` is non-empty and sorted ascending.
+    """
+    if not sorted_vals:
+        return math.nan
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    lo = int(math.floor(k))
+    hi = int(math.ceil(k))
+    if lo == hi:
+        return sorted_vals[lo]
+    return (
+        sorted_vals[lo] * (hi - k)
+        + sorted_vals[hi] * (k - lo)
+    )
+
+
+def _compute_signal_stats(
+    signal: str,
+    rows: List[Dict[str, str]],
+    include: List[str],
+) -> Dict[str, Any]:
+    """Compute requested stat groups for a single signal."""
+    samples: List[Tuple[datetime, float]] = []
+    for r in rows:
+        ts = parse_timestamp(r.get("Timestamp", ""))
+        v = try_float(r.get(signal, ""))
+        if ts is not None and v is not None:
+            samples.append((ts, v))
+
+    out: Dict[str, Any] = {
+        "signal": signal,
+        "valid": len(samples),
+        "total": len(rows),
+    }
+
+    if not samples:
+        out["notes"] = "all N/A in window"
+        return out
+
+    values = [v for _, v in samples]
+    sorted_vals = sorted(values)
+    n = len(values)
+    mean = sum(values) / n
+    var = sum((v - mean) ** 2 for v in values) / n
+    std = math.sqrt(var)
+
+    if "basic" in include:
+        out["min"] = sorted_vals[0]
+        out["max"] = sorted_vals[-1]
+        out["mean"] = mean
+        out["std"] = std
+
+    if "percentiles" in include:
+        out["p5"] = _percentile(sorted_vals, 5)
+        out["p25"] = _percentile(sorted_vals, 25)
+        out["p50"] = _percentile(sorted_vals, 50)
+        out["p75"] = _percentile(sorted_vals, 75)
+        out["p95"] = _percentile(sorted_vals, 95)
+
+    if "trend" in include and n >= 3:
+        # Simple linear regression slope vs. sample index (per-sec
+        # gradient would need uniform spacing — index slope is
+        # safer and still tells the agent if it's rising/falling).
+        xs = list(range(n))
+        x_mean = sum(xs) / n
+        cov = sum(
+            (xs[i] - x_mean) * (values[i] - mean)
+            for i in range(n)
+        )
+        denom = sum((x - x_mean) ** 2 for x in xs)
+        slope = cov / denom if denom else 0.0
+        out["linreg_slope_per_sample"] = slope
+        # Autocorr lag-1
+        if std > 0 and n > 2:
+            cov1 = sum(
+                (values[i] - mean) * (values[i - 1] - mean)
+                for i in range(1, n)
+            )
+            out["autocorr_lag1"] = cov1 / ((n - 1) * var)
+        else:
+            out["autocorr_lag1"] = None
+    elif "trend" in include:
+        out["notes"] = "trend skipped — fewer than 3 samples"
+
+    if "extrema" in include:
+        max_idx = max(range(n), key=lambda i: values[i])
+        min_idx = min(range(n), key=lambda i: values[i])
+        out["max_at"] = samples[max_idx][0].isoformat()
+        out["min_at"] = samples[min_idx][0].isoformat()
+
+    return out
+
+
+_DEFAULT_INCLUDE = ["basic", "percentiles"]
+
+
+async def get_signal_stats(input_data: Dict[str, Any]) -> str:
+    """Summarize signals with descriptive statistics.
+
+    Returns a per-signal stats block.  Reuses the in-house stat
+    machinery (kept local rather than depending on
+    ``statistics_extractor`` to avoid pulling in the
+    NormalizedTimeSeries pipeline — which strips Yamaha proprietary
+    columns).  Output values match numpy reference within
+    floating-point tolerance.
+
+    Args:
+        input_data: ``GetSignalStatsInput`` + ``_session_id``.
+
+    Returns:
+        Tabular text.
+    """
+    session_id = input_data["_session_id"]
+    requested_signals: List[str] = input_data["signals"]
+    time_range = input_data.get("time_range")
+    include = input_data.get("include") or _DEFAULT_INCLUDE
+
+    data, inventory = _ensure_data(session_id)
+
+    resolved: List[str] = []
+    unknown: List[str] = []
+    for s in requested_signals:
+        canon = resolve_signal_name(s, inventory)
+        if canon is None:
+            unknown.append(s)
+        else:
+            resolved.append(canon)
+
+    if not resolved:
+        return _unknown_signal_message(
+            unknown[0] if unknown else "",
+            inventory,
+        )
+
+    # Apply time-range filter.
+    start = end = None
+    if time_range:
+        start_raw, end_raw = time_range
+        start = _parse_window_bound(start_raw)
+        end = _parse_window_bound(end_raw)
+    rows = _filter_rows_by_time(data.rows, start, end)
+
+    if not rows:
+        return (
+            "No samples in the requested time range. Use "
+            "`list_signals` to see the session time span."
+        )
+
+    # Compute stats per signal.
+    per_signal = [
+        _compute_signal_stats(s, rows, include)
+        for s in resolved
+    ]
+
+    # Render
+    lines: List[str] = []
+    lines.append("Signal statistics")
+    if start and end:
+        lines.append(
+            f"Window: {start.isoformat()} → {end.isoformat()} "
+            f"({len(rows)} samples)"
+        )
+    else:
+        lines.append(f"Window: full session ({len(rows)} samples)")
+    lines.append(f"Included: {', '.join(include)}")
+    lines.append("")
+
+    unit_lookup = {d.name: d.units for d in inventory}
+
+    for stats in per_signal:
+        sig = stats["signal"]
+        unit = unit_lookup.get(sig, "?")
+        lines.append(
+            f"=== {sig} ({unit}) — "
+            f"{stats['valid']}/{stats['total']} valid samples ==="
+        )
+        for k in (
+            "min", "max", "mean", "std",
+            "p5", "p25", "p50", "p75", "p95",
+            "linreg_slope_per_sample", "autocorr_lag1",
+            "max_at", "min_at",
+        ):
+            if k in stats and stats[k] is not None:
+                val = stats[k]
+                if isinstance(val, float):
+                    lines.append(f"  {k}: {val:.4f}")
+                else:
+                    lines.append(f"  {k}: {val}")
+        if "notes" in stats:
+            lines.append(f"  notes: {stats['notes']}")
+        lines.append("")
+
+    if unknown:
+        lines.append(
+            f"Ignored unrecognized signals: {unknown}"
+        )
+
+    return "\n".join(lines).rstrip()
+
+
+# ── find_events ──────────────────────────────────────────────────
+
+
+def _predicate_holds(
+    predicate: str,
+    threshold: Optional[float],
+    value: Optional[float],
+    prev_value: Optional[float],
+    dt_seconds: Optional[float],
+) -> bool:
+    """Evaluate a predicate at one sample.
+
+    For ``rising_above`` / ``falling_below`` the event is the
+    *crossing* — defined as ``prev`` on the wrong side and current
+    on the correct side.  For ``rate_of_change_*`` we use the
+    finite difference ``(value - prev) / dt`` in units per second.
+    """
+    if predicate == "missing":
+        return value is None
+    if value is None:
+        return False
+    if threshold is None:
+        return False
+
+    if predicate == "above_threshold":
+        return value > threshold
+    if predicate == "below_threshold":
+        return value < threshold
+    if predicate == "rising_above":
+        if prev_value is None:
+            return False
+        return prev_value <= threshold < value
+    if predicate == "falling_below":
+        if prev_value is None:
+            return False
+        return prev_value >= threshold > value
+    if predicate == "rate_of_change_above":
+        if prev_value is None or dt_seconds is None or dt_seconds <= 0:
+            return False
+        return (value - prev_value) / dt_seconds > threshold
+    if predicate == "rate_of_change_below":
+        if prev_value is None or dt_seconds is None or dt_seconds <= 0:
+            return False
+        return (value - prev_value) / dt_seconds < threshold
+    return False
+
+
+async def find_events(input_data: Dict[str, Any]) -> str:
+    """Find time windows where a signal meets a predicate.
+
+    Returns a list of ``(start, end, duration, peak)`` events
+    sorted by start time, with short events filtered out and
+    adjacent events merged per the input options.
+
+    Args:
+        input_data: ``FindEventsInput`` + ``_session_id``.
+
+    Returns:
+        Event-list text.
+    """
+    session_id = input_data["_session_id"]
+    signal_req: str = input_data["signal"]
+    predicate: str = input_data["predicate"]
+    threshold: Optional[float] = input_data.get("threshold")
+    min_duration: float = float(
+        input_data.get("min_duration_seconds", 1.0),
+    )
+    merge_gap: float = float(
+        input_data.get("merge_gap_seconds", 2.0),
+    )
+    max_events: int = int(input_data.get("max_events", 20))
+    time_range = input_data.get("time_range")
+
+    if predicate != "missing" and threshold is None:
+        return (
+            f"Validation error: predicate '{predicate}' requires "
+            f"the `threshold` parameter. Example: "
+            f"find_events(signal='{signal_req}', predicate="
+            f"'{predicate}', threshold=3000)."
+        )
+
+    data, inventory = _ensure_data(session_id)
+    signal = resolve_signal_name(signal_req, inventory)
+    if signal is None:
+        return _unknown_signal_message(signal_req, inventory)
+
+    start = end = None
+    if time_range:
+        start_raw, end_raw = time_range
+        start = _parse_window_bound(start_raw)
+        end = _parse_window_bound(end_raw)
+    rows = _filter_rows_by_time(data.rows, start, end)
+
+    if not rows:
+        return (
+            "No samples in the requested time range."
+        )
+
+    # Walk rows.  Build (timestamp, value) sequence including
+    # missing values for the 'missing' predicate.
+    sequence: List[Tuple[datetime, Optional[float]]] = []
+    for r in rows:
+        ts = parse_timestamp(r.get("Timestamp", ""))
+        if ts is None:
+            continue
+        sequence.append((ts, try_float(r.get(signal, ""))))
+
+    if not sequence:
+        return (
+            f"Signal '{signal}' has no valid timestamped rows."
+        )
+
+    # Collect raw event spans.
+    events: List[Dict[str, Any]] = []
+    in_event = False
+    cur_start: Optional[datetime] = None
+    cur_end: Optional[datetime] = None
+    cur_peak: Optional[float] = None
+    prev_val: Optional[float] = None
+    prev_ts: Optional[datetime] = None
+
+    def _close_event():
+        nonlocal cur_start, cur_end, cur_peak, in_event
+        if cur_start is not None and cur_end is not None:
+            events.append({
+                "start": cur_start,
+                "end": cur_end,
+                "peak": cur_peak,
+            })
+        cur_start = cur_end = cur_peak = None
+        in_event = False
+
+    for ts, v in sequence:
+        dt = (
+            (ts - prev_ts).total_seconds()
+            if prev_ts is not None else None
+        )
+        hit = _predicate_holds(
+            predicate, threshold, v, prev_val, dt,
+        )
+        if hit:
+            if not in_event:
+                cur_start = ts
+                cur_peak = v
+                in_event = True
+            cur_end = ts
+            if v is not None:
+                if cur_peak is None:
+                    cur_peak = v
+                elif predicate in (
+                    "above_threshold", "rising_above",
+                    "rate_of_change_above",
+                ):
+                    cur_peak = max(cur_peak, v)
+                elif predicate in (
+                    "below_threshold", "falling_below",
+                    "rate_of_change_below",
+                ):
+                    cur_peak = min(cur_peak, v)
+        else:
+            if in_event:
+                _close_event()
+        prev_val = v
+        prev_ts = ts
+    if in_event:
+        _close_event()
+
+    # Filter by min_duration.
+    filtered = []
+    for ev in events:
+        dur = (ev["end"] - ev["start"]).total_seconds()
+        if dur >= min_duration:
+            ev["duration_s"] = dur
+            filtered.append(ev)
+
+    # Merge adjacent events whose gap < merge_gap.
+    merged: List[Dict[str, Any]] = []
+    for ev in filtered:
+        if not merged:
+            merged.append(ev)
+            continue
+        gap = (ev["start"] - merged[-1]["end"]).total_seconds()
+        if gap <= merge_gap:
+            merged[-1]["end"] = ev["end"]
+            merged[-1]["duration_s"] = (
+                merged[-1]["end"] - merged[-1]["start"]
+            ).total_seconds()
+            # Update peak.
+            a = merged[-1]["peak"]
+            b = ev["peak"]
+            if a is None:
+                merged[-1]["peak"] = b
+            elif b is None:
+                pass
+            elif predicate in (
+                "above_threshold", "rising_above",
+                "rate_of_change_above",
+            ):
+                merged[-1]["peak"] = max(a, b)
+            elif predicate in (
+                "below_threshold", "falling_below",
+                "rate_of_change_below",
+            ):
+                merged[-1]["peak"] = min(a, b)
+        else:
+            merged.append(ev)
+
+    truncated = len(merged) > max_events
+    shown = merged[:max_events]
+
+    unit = next(
+        (d.units for d in inventory if d.name == signal), "?",
+    )
+    lines: List[str] = []
+    if predicate == "missing":
+        header = (
+            f"Events — signal '{signal}' missing (N/A) — "
+            f"{len(shown)} of {len(merged)} found"
+            + (" [truncated]" if truncated else "")
+        )
+    else:
+        header = (
+            f"Events — '{signal}' {predicate} {threshold} {unit} — "
+            f"{len(shown)} of {len(merged)} found"
+            + (" [truncated]" if truncated else "")
+        )
+    lines.append(header)
+    lines.append(
+        f"Filters: min_duration={min_duration}s, "
+        f"merge_gap={merge_gap}s"
+    )
+    lines.append("")
+
+    if not shown:
+        # Provide a helpful "max in range" anchor when no events
+        # match a value predicate.
+        if predicate in (
+            "above_threshold", "rising_above",
+            "rate_of_change_above",
+            "below_threshold", "falling_below",
+            "rate_of_change_below",
+        ):
+            numeric_vals = [
+                v for _, v in sequence if v is not None
+            ]
+            if numeric_vals:
+                lines.append(
+                    f"No events matched. Signal range in this "
+                    f"window: min={min(numeric_vals):.2f}, "
+                    f"max={max(numeric_vals):.2f} {unit}. "
+                    f"Consider adjusting the threshold."
+                )
+            else:
+                lines.append(
+                    f"No events matched — signal '{signal}' has "
+                    f"no valid samples in the window."
+                )
+        else:
+            lines.append("No events matched.")
+        return "\n".join(lines)
+
+    for i, ev in enumerate(shown, start=1):
+        peak = ev["peak"]
+        peak_str = (
+            f"peak={peak:.2f}" if peak is not None else "peak=N/A"
+        )
+        lines.append(
+            f"#{i}  {ev['start'].isoformat()} → "
+            f"{ev['end'].isoformat()}  "
+            f"({_format_duration(ev['duration_s'])})  "
+            f"{peak_str} {unit}"
+        )
+
+    return "\n".join(lines)
+
+
+# ── ToolDefinition exports ───────────────────────────────────────
+
+
+_LIST_SIGNALS_DESC = (
+    "List the signals (columns) present in this session's OBD "
+    "log. Returns time range, sampling rate, ECU channel "
+    "presence, and a per-signal inventory with units and data "
+    "density. Use FIRST to discover what signals exist; "
+    "filter with pattern (glob, e.g. '*TEMP*', 'A_YAM_*') and "
+    "subsystem ('engine'/'abs'/'all'). Cheap — call freely."
+)
+
+_READ_WINDOW_DESC = (
+    "Read raw samples for one or more signals in a time window. "
+    "Returns a tab-separated table with timestamps, values, and "
+    "units. Auto-downsamples to max_rows (default 50, hard cap "
+    "500). Use AFTER list_signals to inspect specific values. "
+    "Prefer get_signal_stats if you only need aggregates — much "
+    "cheaper."
+)
+
+_GET_SIGNAL_STATS_DESC = (
+    "Summarize 1-10 signals with descriptive statistics over a "
+    "time range (or full session). Returns min/max/mean/std/"
+    "percentiles (p5/p25/p50/p75/p95), optionally trend (linear "
+    "regression slope, lag-1 autocorrelation) and extrema "
+    "timestamps. Use to answer 'what's the distribution?' "
+    "without pulling raw rows."
+)
+
+_FIND_EVENTS_DESC = (
+    "Find time windows where a signal meets a condition "
+    "(above/below threshold, rising_above/falling_below "
+    "crossings, rate_of_change_above/below in units-per-second, "
+    "or missing N/A). Returns event spans with peak values. "
+    "Use to locate 'when did X happen' without scanning the "
+    "whole log. Predicates other than 'missing' require a "
+    "threshold parameter."
+)
+
+
+LIST_SIGNALS_DEF = ToolDefinition(
+    name="list_signals",
+    description=_LIST_SIGNALS_DESC,
+    input_schema=ListSignalsInput.model_json_schema(),
+    handler=list_signals,
+    input_model=ListSignalsInput,
+    is_read_only=True,
+    max_result_chars=10_000,
+)
+
+
+READ_WINDOW_DEF = ToolDefinition(
+    name="read_window",
+    description=_READ_WINDOW_DESC,
+    input_schema=ReadWindowInput.model_json_schema(),
+    handler=read_window,
+    input_model=ReadWindowInput,
+    is_read_only=True,
+    max_result_chars=50_000,
+)
+
+
+GET_SIGNAL_STATS_DEF = ToolDefinition(
+    name="get_signal_stats",
+    description=_GET_SIGNAL_STATS_DESC,
+    input_schema=GetSignalStatsInput.model_json_schema(),
+    handler=get_signal_stats,
+    input_model=GetSignalStatsInput,
+    is_read_only=True,
+    max_result_chars=20_000,
+)
+
+
+FIND_EVENTS_DEF = ToolDefinition(
+    name="find_events",
+    description=_FIND_EVENTS_DESC,
+    input_schema=FindEventsInput.model_json_schema(),
+    handler=find_events,
+    input_model=FindEventsInput,
+    is_read_only=True,
+    max_result_chars=20_000,
+)

--- a/diagnostic_api/tests/harness_tools/__init__.py
+++ b/diagnostic_api/tests/harness_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for harness tools."""

--- a/diagnostic_api/tests/harness_tools/test_obd_dtcs.py
+++ b/diagnostic_api/tests/harness_tools/test_obd_dtcs.py
@@ -1,0 +1,259 @@
+"""Unit tests for the OBD DTC tools (HARNESS-19).
+
+Exercises ``list_dtcs`` and ``lookup_dtc`` against the real Yamaha
+road-test fixture.  Validates the locked design decision: Yamaha
+proprietary hex DTCs are surfaced honestly with a manual-search
+pivot, never fabricated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.harness_tools.obd_dtcs import (
+    _classify_code,
+    list_dtcs,
+    lookup_dtc,
+)
+from app.harness_tools.obd_loader import OBDLogData, load_obd_data
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_YAMAHA_FIXTURE = (
+    _REPO_ROOT
+    / "obd_agent"
+    / "fixtures"
+    / "yamaha_dual_road_test_20260508.csv"
+)
+
+FAKE_SESSION_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture(scope="module")
+def yamaha_data() -> OBDLogData:
+    return load_obd_data(_YAMAHA_FIXTURE)
+
+
+@pytest.fixture(autouse=True)
+def _mock_load(yamaha_data: OBDLogData):
+    """Short-circuit DB lookup with the parsed fixture."""
+    with patch(
+        "app.harness_tools.obd_dtcs.load_for_session",
+        return_value=yamaha_data,
+    ):
+        yield
+
+
+# ── _classify_code ───────────────────────────────────────────────
+
+
+class TestClassifyCode:
+    """Unit tests for the format classifier."""
+
+    def test_standard_p_code(self) -> None:
+        assert _classify_code("P0117") == "standard"
+        assert _classify_code("p0117") == "standard"
+
+    def test_standard_c_code(self) -> None:
+        assert _classify_code("C0035") == "standard"
+
+    def test_standard_b_code(self) -> None:
+        assert _classify_code("B1234") == "standard"
+
+    def test_standard_u_code(self) -> None:
+        assert _classify_code("U0100") == "standard"
+
+    def test_yamaha_hex_long_hex(self) -> None:
+        """The fixture's 22-char hex codes classify as yamaha_hex."""
+        assert _classify_code(
+            "87F11043000000000000CB",
+        ) == "yamaha_hex"
+
+    def test_unknown_short_string(self) -> None:
+        assert _classify_code("X1234") == "unknown"
+
+    def test_unknown_too_short_hex(self) -> None:
+        """8-byte+ minimum for Yamaha hex classification."""
+        assert _classify_code("ABCDEF") == "unknown"
+
+
+# ── list_dtcs against the real fixture ───────────────────────────
+
+
+class TestListDTCsRealFixture:
+    """Tests for ``list_dtcs`` against the Yamaha fixture.
+
+    The fixture has 2 Yamaha-hex DTCs in the metadata block
+    (1 stored, 1 pending) and no column-level DTCs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lists_two_yamaha_hex_dtcs(self) -> None:
+        """Fixture metadata yields exactly 2 DTCs."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+            "status": "all",
+            "ecu": "all",
+        })
+        assert "87F11043000000000000CB" in result
+        assert "87F11047000000000000CF" in result
+
+    @pytest.mark.asyncio
+    async def test_groups_yamaha_hex_separately(self) -> None:
+        """Output has a 'Yamaha-proprietary' section header."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+        })
+        assert "Yamaha-proprietary" in result
+
+    @pytest.mark.asyncio
+    async def test_separates_stored_vs_pending(self) -> None:
+        """Both status values appear in the output."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+        })
+        assert "STORED" in result
+        assert "PENDING" in result
+
+    @pytest.mark.asyncio
+    async def test_status_filter_stored(self) -> None:
+        """status='stored' surfaces only the stored code."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+            "status": "stored",
+        })
+        assert "87F11043000000000000CB" in result
+        assert "87F11047000000000000CF" not in result
+
+    @pytest.mark.asyncio
+    async def test_status_filter_pending(self) -> None:
+        """status='pending' surfaces only the pending code."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+            "status": "pending",
+        })
+        assert "87F11047000000000000CF" in result
+        assert "87F11043000000000000CB" not in result
+
+    @pytest.mark.asyncio
+    async def test_abs_ecu_filter_empty(self) -> None:
+        """Fixture has no ABS DTCs — abs filter is empty."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+            "ecu": "abs",
+        })
+        # Should not surface either K-Line code.
+        assert "87F11043000000000000CB" not in result
+
+    @pytest.mark.asyncio
+    async def test_notes_guide_agent_to_lookup_dtc(self) -> None:
+        """Output reminds the agent to call lookup_dtc."""
+        result = await list_dtcs({
+            "_session_id": FAKE_SESSION_ID,
+        })
+        assert "lookup_dtc" in result
+
+
+class TestListDTCsEmptySession:
+    """Tests for sessions with no DTCs (informational, not error)."""
+
+    @pytest.mark.asyncio
+    async def test_no_dtcs_returns_informational_message(self) -> None:
+        """An empty DTC list is information, not an error."""
+        empty_data = OBDLogData(
+            format="standard_tsv",
+            rows=[
+                {"Timestamp": "2026-05-08 11:00:00", "RPM": "1500"},
+            ],
+            columns=["RPM"],
+            metadata_dtcs=[],
+            metadata_lines=[],
+            channels_present={"engine"},
+        )
+        with patch(
+            "app.harness_tools.obd_dtcs.load_for_session",
+            return_value=empty_data,
+        ):
+            result = await list_dtcs({
+                "_session_id": FAKE_SESSION_ID,
+            })
+        assert "No DTCs found" in result
+
+
+# ── lookup_dtc ───────────────────────────────────────────────────
+
+
+class TestLookupDTCYamahaHex:
+    """Tests for the honest 'no decoder' Yamaha hex pivot."""
+
+    @pytest.mark.asyncio
+    async def test_returns_no_decoder_message(self) -> None:
+        """The locked decision: surface honestly, do not fabricate."""
+        result = await lookup_dtc({
+            "code": "87F11043000000000000CB",
+        })
+        assert "Yamaha-proprietary" in result
+        assert "No decoder available" in result
+
+    @pytest.mark.asyncio
+    async def test_suggests_search_manual_pivot(self) -> None:
+        """Output guides the agent to search_manual."""
+        result = await lookup_dtc({
+            "code": "87F11043000000000000CB",
+        })
+        assert "search_manual" in result
+
+    @pytest.mark.asyncio
+    async def test_does_not_fabricate_decoding(self) -> None:
+        """Crucial: no fake P-code mapping or made-up description."""
+        result = await lookup_dtc({
+            "code": "87F11043000000000000CB",
+        })
+        # Should NOT claim it's a standard P/C/B/U code.
+        assert "Description: Coolant" not in result
+        assert "P0117" not in result
+
+
+class TestLookupDTCStandard:
+    """Tests for standard P/C/B/U code decoding."""
+
+    @pytest.mark.asyncio
+    async def test_classifies_p_code_as_powertrain(self) -> None:
+        result = await lookup_dtc({"code": "P0117"})
+        assert "standard OBD-II code" in result
+        assert "powertrain" in result.lower() or "engine" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_classifies_c_code_as_chassis(self) -> None:
+        result = await lookup_dtc({"code": "C0035"})
+        assert "chassis" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_includes_related_signals_for_known_p_code(
+        self,
+    ) -> None:
+        """Curated map includes related signals for P0117."""
+        result = await lookup_dtc({"code": "P0117"})
+        assert "COOLANT_TEMP" in result
+
+    @pytest.mark.asyncio
+    async def test_suggests_search_manual_next_step(self) -> None:
+        """Output suggests pulling the manufacturer's procedure."""
+        result = await lookup_dtc({"code": "P0117"})
+        assert "search_manual" in result
+
+
+class TestLookupDTCUnknown:
+    """Tests for unrecognized code formats."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_format_gives_actionable_error(self) -> None:
+        result = await lookup_dtc({"code": "X1234"})
+        assert "not a recognised" in result.lower() or "verify" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_code_validation_error(self) -> None:
+        result = await lookup_dtc({"code": ""})
+        assert "Validation error" in result or "non-empty" in result.lower()

--- a/diagnostic_api/tests/harness_tools/test_obd_loader.py
+++ b/diagnostic_api/tests/harness_tools/test_obd_loader.py
@@ -1,0 +1,269 @@
+"""Unit tests for the Yamaha-aware OBD log loader.
+
+Exercises ``detect_format``, the Yamaha-dual CSV parser, and the
+metadata-DTC extractor against the real road-test fixture.
+
+The fixture lives at ``obd_agent/fixtures/yamaha_dual_road_test_20260508.csv``
+— a 257-sample real recording committed in #80 (PR #82).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.harness_tools.obd_loader import (
+    OBDLogData,
+    _parse_yamaha_metadata_dtcs,
+    detect_format,
+    load_obd_data,
+    parse_timestamp,
+    try_float,
+)
+
+# Path to the real Yamaha road-test fixture.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_YAMAHA_FIXTURE = (
+    _REPO_ROOT
+    / "obd_agent"
+    / "fixtures"
+    / "yamaha_dual_road_test_20260508.csv"
+)
+
+
+@pytest.fixture(scope="module")
+def yamaha_data() -> OBDLogData:
+    """Parse the Yamaha fixture once for the module."""
+    assert _YAMAHA_FIXTURE.exists(), (
+        f"Yamaha fixture missing: {_YAMAHA_FIXTURE}"
+    )
+    return load_obd_data(_YAMAHA_FIXTURE)
+
+
+# ── Format detection ─────────────────────────────────────────────
+
+
+class TestDetectFormat:
+    """Tests for ``detect_format``."""
+
+    def test_detects_yamaha_dual_from_marker_comment(self) -> None:
+        """The 'Yamaha Dual' marker in the header is recognized."""
+        sample = "\n".join([
+            "# Yamaha Dual OBDLink EX Log",
+            "# vehicle_id: TEST",
+            "Timestamp,A_KL_RPM",
+            "2026-05-08 11:00:00.000,1500.0",
+        ])
+        assert detect_format(sample) == "yamaha_dual"
+
+    def test_detects_yamaha_from_a_kl_columns(self) -> None:
+        """A_KL_ / A_YAM_ column prefixes trigger Yamaha detection
+        even without the comment marker (defense-in-depth)."""
+        sample = "\n".join([
+            "# Ch.A: K-Line",
+            "Timestamp,A_KL_RPM",
+            "t,1500",
+        ])
+        assert detect_format(sample) == "yamaha_dual"
+
+    def test_detects_standard_tsv(self) -> None:
+        """Standard python-OBD TSV format is recognised."""
+        sample = "\n".join([
+            "OBD Data Log",
+            "Start Time: 2025-01-01 00:00:00",
+            "--------",
+            "Timestamp\tRPM\tSPEED",
+            "--------",
+            "2025-01-01 00:00:00\t1500\t30",
+        ])
+        assert detect_format(sample) == "standard_tsv"
+
+    def test_unknown_format_returns_unknown(self) -> None:
+        """Non-OBD content gets the unknown tag."""
+        assert detect_format("hello world") == "unknown"
+
+    def test_detects_real_yamaha_fixture(self) -> None:
+        """The committed fixture file is classified as yamaha_dual."""
+        text = _YAMAHA_FIXTURE.read_text(encoding="utf-8")
+        assert detect_format(text) == "yamaha_dual"
+
+
+# ── Yamaha metadata DTC extractor ────────────────────────────────
+
+
+class TestYamahaMetadataDTCs:
+    """Tests for ``_parse_yamaha_metadata_dtcs``."""
+
+    def test_extracts_stored_and_pending(self) -> None:
+        """Stored and pending DTC lines are parsed with status tags."""
+        lines = [
+            "# DTCs:",
+            "#   KL_Stored: 87F11043000000000000CB",
+            "#   KL_Pending: 87F11047000000000000CF",
+        ]
+        out = _parse_yamaha_metadata_dtcs(lines)
+        assert len(out) == 2
+        statuses = {d.status for d in out}
+        assert statuses == {"stored", "pending"}
+        codes = [d.code for d in out]
+        assert "87F11043000000000000CB" in codes
+        assert "87F11047000000000000CF" in codes
+
+    def test_attaches_ecu_label(self) -> None:
+        """KL_ prefix maps to 'K-Line' ECU label."""
+        out = _parse_yamaha_metadata_dtcs([
+            "#   KL_Stored: ABCDEF0123",
+        ])
+        assert out[0].ecu == "K-Line"
+
+    def test_skips_unrelated_metadata_lines(self) -> None:
+        """Non-DTC metadata lines are ignored without erroring."""
+        out = _parse_yamaha_metadata_dtcs([
+            "# vehicle_id: TEST",
+            "# Start: 2026-05-08 11:00:00",
+        ])
+        assert out == []
+
+
+# ── End-to-end: parse the real fixture ───────────────────────────
+
+
+class TestRealYamahaFixture:
+    """Tests against the committed Yamaha road-test fixture.
+
+    Validates the HARNESS-19 locked decision: ``A_YAM_*`` proprietary
+    columns are exposed under their original names, and the metadata
+    block's Yamaha hex DTCs are surfaced.
+    """
+
+    def test_format_classified_as_yamaha_dual(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        assert yamaha_data.format == "yamaha_dual"
+
+    def test_rows_loaded(self, yamaha_data: OBDLogData) -> None:
+        """The fixture has roughly 257 data rows."""
+        # Fixture committed shape: 257 samples per #80 PR description.
+        # Allow a small tolerance in case the committed file is
+        # tweaked later (no semantic regression as long as it's
+        # well over 100 samples).
+        assert len(yamaha_data.rows) > 200
+
+    def test_a_yam_columns_preserved(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """A_YAM_* proprietary columns survive the loader.
+
+        This is the HARNESS-19 locked decision — the legacy
+        format_normalizer.py drops these, the new loader must NOT.
+        """
+        yamaha_cols = [
+            c for c in yamaha_data.columns
+            if c.startswith("A_YAM_")
+        ]
+        # Fixture has 16 A_YAM_* columns per the header (see CSV
+        # rows 9-10).
+        assert len(yamaha_cols) >= 10, (
+            f"Expected A_YAM_* columns to be preserved, got "
+            f"{yamaha_cols}"
+        )
+
+    def test_a_kl_columns_preserved(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """K-Line canonical PIDs are present."""
+        for col in (
+            "A_KL_RPM",
+            "A_KL_SPEED",
+            "A_KL_COOLANT_TEMP",
+            "A_KL_MAP",
+        ):
+            assert col in yamaha_data.columns, (
+                f"Missing K-Line column {col}"
+            )
+
+    def test_metadata_dtcs_extracted(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Fixture's 2 Yamaha-hex DTCs are surfaced via metadata."""
+        assert len(yamaha_data.metadata_dtcs) == 2
+        codes = [d.code for d in yamaha_data.metadata_dtcs]
+        assert "87F11043000000000000CB" in codes
+        assert "87F11047000000000000CF" in codes
+        statuses = sorted(d.status for d in yamaha_data.metadata_dtcs)
+        assert statuses == ["pending", "stored"]
+
+    def test_engine_channel_present(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Engine ECU (K-Line) channel detected from A_* columns."""
+        assert "engine" in yamaha_data.channels_present
+
+    def test_first_row_is_warmup_na(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """First data row contains N/A — sensor warm-up."""
+        first = yamaha_data.rows[0]
+        # Fixture row 17 (first data row) is all N/A.
+        rpm_val = first.get("A_KL_RPM", "")
+        assert rpm_val.strip().upper() == "N/A"
+
+    def test_subsequent_rows_have_numeric_values(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Rows after warm-up contain parseable floats."""
+        # Row index 1 should have numeric RPM (e.g. 0.0 idle).
+        second = yamaha_data.rows[1]
+        assert try_float(second["A_KL_RPM"]) is not None
+
+
+# ── Time helpers ─────────────────────────────────────────────────
+
+
+class TestTimestampParser:
+    """Tests for ``parse_timestamp``."""
+
+    def test_parses_millisecond_format(self) -> None:
+        """Fixture format with .508 ms suffix parses."""
+        dt = parse_timestamp("2026-05-08 11:20:40.508")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.second == 40
+
+    def test_parses_second_precision(self) -> None:
+        dt = parse_timestamp("2026-05-08 11:20:40")
+        assert dt is not None
+
+    def test_parses_iso_t_separator(self) -> None:
+        dt = parse_timestamp("2026-05-08T11:20:40")
+        assert dt is not None
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert parse_timestamp("not a date") is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert parse_timestamp("") is None
+
+
+class TestTryFloat:
+    """Tests for ``try_float`` missing-value handling."""
+
+    def test_n_a_token_returns_none(self) -> None:
+        assert try_float("N/A") is None
+
+    def test_n_a_lowercase_returns_none(self) -> None:
+        assert try_float("n/a") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert try_float("") is None
+        assert try_float("   ") is None
+
+    def test_nan_returns_none(self) -> None:
+        assert try_float("nan") is None
+
+    def test_numeric_string_returns_float(self) -> None:
+        assert try_float("3.14") == pytest.approx(3.14)
+
+    def test_integer_string_returns_float(self) -> None:
+        assert try_float("42") == 42.0

--- a/diagnostic_api/tests/harness_tools/test_obd_signals.py
+++ b/diagnostic_api/tests/harness_tools/test_obd_signals.py
@@ -1,0 +1,495 @@
+"""Unit tests for the OBD signal tools (HARNESS-19).
+
+Exercises ``list_signals``, ``read_window``, ``get_signal_stats``,
+and ``find_events`` against the real Yamaha road-test fixture.
+
+All tests mock ``load_for_session`` to short-circuit the DB lookup
+so they run hermetically without a Postgres instance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.harness_tools.obd_loader import OBDLogData, load_obd_data
+from app.harness_tools.obd_signal_inventory import (
+    build_inventory,
+    classify_subsystem,
+    filter_inventory,
+    fuzzy_suggestions,
+    resolve_signal_name,
+    units_for,
+)
+from app.harness_tools.obd_signals import (
+    find_events,
+    get_signal_stats,
+    list_signals,
+    read_window,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_YAMAHA_FIXTURE = (
+    _REPO_ROOT
+    / "obd_agent"
+    / "fixtures"
+    / "yamaha_dual_road_test_20260508.csv"
+)
+
+FAKE_SESSION_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture(scope="module")
+def yamaha_data() -> OBDLogData:
+    return load_obd_data(_YAMAHA_FIXTURE)
+
+
+@pytest.fixture(autouse=True)
+def _mock_load(yamaha_data: OBDLogData):
+    """Patch the DB-backed loader to return the fixture directly."""
+    with patch(
+        "app.harness_tools.obd_signals.load_for_session",
+        return_value=yamaha_data,
+    ):
+        yield
+
+
+# ── Inventory helpers ────────────────────────────────────────────
+
+
+class TestSignalInventory:
+    """Unit tests for the inventory helpers."""
+
+    def test_classify_subsystem_engine_for_a_kl(self) -> None:
+        assert classify_subsystem("A_KL_RPM") == "engine"
+        assert classify_subsystem("A_YAM_INJ_MS") == "engine"
+
+    def test_classify_subsystem_abs_for_b_prefix(self) -> None:
+        assert classify_subsystem("B_ABS_PRESSURE") == "abs"
+
+    def test_classify_subsystem_engine_for_standard_pid(self) -> None:
+        """Standard OBD PIDs (no prefix) classify as engine."""
+        assert classify_subsystem("RPM") == "engine"
+        assert classify_subsystem("COOLANT_TEMP") == "engine"
+
+    def test_units_for_kl_canonical(self) -> None:
+        assert units_for("A_KL_RPM") == "rpm"
+        assert units_for("A_KL_COOLANT_TEMP") == "°C"
+
+    def test_units_for_yamaha_proprietary(self) -> None:
+        """HARNESS-19 unit map covers known A_YAM_* fields."""
+        assert units_for("A_YAM_INJ_MS") == "ms"
+        assert units_for("A_YAM_BATT_V") == "V"
+
+    def test_units_for_yamaha_raw_marked_raw(self) -> None:
+        """Provisional A_YAM_*_RAW fields are tagged as raw bytes."""
+        assert units_for("A_YAM_BATT_RAW") == "raw"
+
+    def test_units_for_unknown_falls_back(self) -> None:
+        assert units_for("NEVER_HEARD_OF") == "unknown"
+
+    def test_resolve_signal_name_exact_match(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        assert resolve_signal_name("A_KL_RPM", inv) == "A_KL_RPM"
+
+    def test_resolve_signal_name_case_insensitive(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        assert resolve_signal_name("a_kl_rpm", inv) == "A_KL_RPM"
+
+    def test_resolve_signal_name_suffix_prefers_kl(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """RPM should resolve to A_KL_RPM (shorter) over A_YAM_RPM."""
+        inv = build_inventory(yamaha_data)
+        assert resolve_signal_name("RPM", inv) == "A_KL_RPM"
+
+    def test_resolve_signal_name_unknown_returns_none(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        assert resolve_signal_name("EGT_BANK_4", inv) is None
+
+    def test_filter_inventory_by_pattern(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        out = filter_inventory(inv, "*temp*", "all")
+        names = [d.name for d in out]
+        assert "A_KL_COOLANT_TEMP" in names
+        assert "A_KL_IAT" not in names  # No 'TEMP' in name
+
+    def test_filter_inventory_by_a_yam_prefix(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        out = filter_inventory(inv, "a_yam_*", "all")
+        for d in out:
+            assert d.name.startswith("A_YAM_")
+        # We expect 16 A_YAM_* columns in the fixture.
+        assert len(out) >= 10
+
+    def test_filter_inventory_engine_subsystem(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        out = filter_inventory(inv, None, "engine")
+        for d in out:
+            assert d.subsystem == "engine"
+
+    def test_filter_inventory_abs_subsystem_empty(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Fixture has no ABS-side columns — abs filter is empty."""
+        inv = build_inventory(yamaha_data)
+        out = filter_inventory(inv, None, "abs")
+        assert out == []
+
+    def test_fuzzy_suggestions_substring_match(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        inv = build_inventory(yamaha_data)
+        out = fuzzy_suggestions("temp", inv)
+        # Should suggest at least one TEMP-containing signal.
+        assert any("TEMP" in s.upper() for s in out)
+
+
+# ── list_signals ─────────────────────────────────────────────────
+
+
+class TestListSignals:
+    """Tests for ``list_signals``."""
+
+    @pytest.mark.asyncio
+    async def test_lists_all_signals(self) -> None:
+        result = await list_signals(
+            {"_session_id": FAKE_SESSION_ID, "subsystem": "all"},
+        )
+        # Channel labels present
+        assert "Engine ECU" in result
+        assert "ABS ECU" in result
+        # Major K-Line signals present
+        assert "A_KL_RPM" in result
+        assert "A_KL_COOLANT_TEMP" in result
+
+    @pytest.mark.asyncio
+    async def test_a_yam_signals_listed_under_original_names(
+        self,
+    ) -> None:
+        """HARNESS-19 locked decision: A_YAM_* exposed verbatim."""
+        result = await list_signals(
+            {"_session_id": FAKE_SESSION_ID},
+        )
+        # At least a few well-known Yamaha proprietary fields:
+        assert "A_YAM_INJ_MS" in result
+        assert "A_YAM_BATT_V" in result
+        assert "A_YAM_CHT" in result
+
+    @pytest.mark.asyncio
+    async def test_pattern_filter_narrows_inventory(self) -> None:
+        result = await list_signals({
+            "_session_id": FAKE_SESSION_ID,
+            "pattern": "*temp*",
+        })
+        assert "A_KL_COOLANT_TEMP" in result
+        assert "A_KL_RPM" not in result
+
+    @pytest.mark.asyncio
+    async def test_abs_subsystem_shows_no_matches(self) -> None:
+        """Fixture has no ABS columns — list shows zero matches."""
+        result = await list_signals({
+            "_session_id": FAKE_SESSION_ID,
+            "subsystem": "abs",
+        })
+        assert "no signals match" in result.lower() or "0 match" in result
+
+    @pytest.mark.asyncio
+    async def test_units_rendered(self) -> None:
+        result = await list_signals(
+            {"_session_id": FAKE_SESSION_ID},
+        )
+        # Yamaha-proprietary units come from the curated map.
+        assert " ms " in result or " ms\n" in result
+        # K-Line canonical RPM unit
+        assert "rpm" in result.lower()
+
+
+# ── read_window ──────────────────────────────────────────────────
+
+
+class TestReadWindow:
+    """Tests for ``read_window``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_table_with_units_row(self) -> None:
+        result = await read_window({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+            "max_rows": 5,
+        })
+        # Header row + units row + sample rows.
+        assert "Timestamp" in result
+        assert "units" in result
+        assert "rpm" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_downsamples_when_window_exceeds_max_rows(
+        self,
+    ) -> None:
+        result = await read_window({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+            "max_rows": 10,
+        })
+        # 257 samples downsampled to 10 — should mention downsample.
+        assert (
+            "downsampled" in result.lower()
+            or "Auto-downsampled" in result
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_signal_fuzzy_suggests(self) -> None:
+        """T2 validation: unknown signal returns a helpful pivot."""
+        result = await read_window({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["EGT"],
+        })
+        # Should not raise. Should hint at known signals.
+        assert (
+            "not in this session" in result.lower()
+            or "did you mean" in result.lower()
+        )
+
+    @pytest.mark.asyncio
+    async def test_inverted_window_returns_clear_error(self) -> None:
+        result = await read_window({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+            "start_time": "2026-05-08T12:00:00",
+            "end_time": "2026-05-08T11:00:00",
+        })
+        assert "Invalid time window" in result
+
+    @pytest.mark.asyncio
+    async def test_window_after_session_end_returns_zero_samples(
+        self,
+    ) -> None:
+        result = await read_window({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+            "start_time": "2030-01-01T00:00:00",
+        })
+        assert (
+            "0 samples" in result.lower()
+            or "after the session end" in result.lower()
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_signals_in_one_call(self) -> None:
+        result = await read_window({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM", "A_KL_COOLANT_TEMP"],
+            "max_rows": 5,
+        })
+        assert "A_KL_RPM" in result
+        assert "A_KL_COOLANT_TEMP" in result
+
+
+# ── get_signal_stats ─────────────────────────────────────────────
+
+
+class TestGetSignalStats:
+    """Tests for ``get_signal_stats``."""
+
+    @pytest.mark.asyncio
+    async def test_basic_stats_include_min_max_mean_std(self) -> None:
+        result = await get_signal_stats({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+        })
+        # Defaults: basic + percentiles
+        assert "min" in result
+        assert "max" in result
+        assert "mean" in result
+        assert "std" in result
+
+    @pytest.mark.asyncio
+    async def test_percentiles_default_included(self) -> None:
+        result = await get_signal_stats({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+        })
+        for k in ("p5", "p25", "p50", "p75", "p95"):
+            assert k in result, (
+                f"Default include should produce {k}, got: {result}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_trend_and_extrema_when_requested(self) -> None:
+        result = await get_signal_stats({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+            "include": ["trend", "extrema"],
+        })
+        assert "max_at" in result
+        assert "min_at" in result
+        # Trend slope or autocorr — at least one must show.
+        assert (
+            "linreg_slope" in result
+            or "autocorr_lag1" in result
+        )
+
+    @pytest.mark.asyncio
+    async def test_yamaha_proprietary_stats_computed(self) -> None:
+        """A_YAM_* signals get stats just like canonical ones."""
+        result = await get_signal_stats({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_YAM_INJ_MS"],
+        })
+        assert "A_YAM_INJ_MS" in result
+        assert "mean" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_signal_returns_fuzzy_message(self) -> None:
+        result = await get_signal_stats({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["DEFINITELY_NOT_A_SIGNAL"],
+        })
+        assert (
+            "not in this session" in result.lower()
+            or "did you mean" in result.lower()
+        )
+
+    @pytest.mark.asyncio
+    async def test_basic_stats_match_reference(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Mean of A_KL_RPM matches direct computation.
+
+        Sanity check that the percentile/mean machinery isn't off
+        by a wide margin.
+        """
+        result = await get_signal_stats({
+            "_session_id": FAKE_SESSION_ID,
+            "signals": ["A_KL_RPM"],
+        })
+        # Compute reference mean from the fixture directly.
+        from app.harness_tools.obd_loader import try_float
+        values = [
+            try_float(r.get("A_KL_RPM", ""))
+            for r in yamaha_data.rows
+        ]
+        values = [v for v in values if v is not None]
+        ref_mean = sum(values) / len(values)
+        # Extract the mean line from the result text.
+        for line in result.splitlines():
+            line = line.strip()
+            if line.startswith("mean:"):
+                got = float(line.split(":", 1)[1].strip())
+                assert got == pytest.approx(
+                    ref_mean, rel=1e-3,
+                )
+                return
+        pytest.fail("mean line not found in get_signal_stats output")
+
+
+# ── find_events ──────────────────────────────────────────────────
+
+
+class TestFindEvents:
+    """Tests for ``find_events``."""
+
+    @pytest.mark.asyncio
+    async def test_rpm_above_zero_finds_engine_running_window(
+        self,
+    ) -> None:
+        result = await find_events({
+            "_session_id": FAKE_SESSION_ID,
+            "signal": "A_KL_RPM",
+            "predicate": "above_threshold",
+            "threshold": 0.0,
+            "min_duration_seconds": 1.0,
+        })
+        # Bike was actively revving — at least one event must
+        # match RPM > 0.
+        assert "Events" in result
+        assert "found" in result
+        # Should not say "0 of 0" — engine was definitely on.
+        assert "0 of 0 found" not in result
+
+    @pytest.mark.asyncio
+    async def test_threshold_required_for_value_predicate(
+        self,
+    ) -> None:
+        """T1 validation: missing threshold returns actionable error."""
+        result = await find_events({
+            "_session_id": FAKE_SESSION_ID,
+            "signal": "A_KL_RPM",
+            "predicate": "above_threshold",
+        })
+        assert (
+            "requires" in result.lower()
+            and "threshold" in result.lower()
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_signal_returns_fuzzy_message(self) -> None:
+        result = await find_events({
+            "_session_id": FAKE_SESSION_ID,
+            "signal": "EGT_BANK_4",
+            "predicate": "above_threshold",
+            "threshold": 1.0,
+        })
+        assert (
+            "not in this session" in result.lower()
+            or "did you mean" in result.lower()
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_events_match_provides_range_anchor(
+        self,
+    ) -> None:
+        """When no events match a value predicate, give max in range."""
+        result = await find_events({
+            "_session_id": FAKE_SESSION_ID,
+            "signal": "A_KL_RPM",
+            "predicate": "above_threshold",
+            "threshold": 100_000.0,
+        })
+        assert "No events matched" in result
+        # Should mention max value or signal range.
+        assert "max" in result.lower() or "range" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_predicate_finds_warmup_na(self) -> None:
+        """The first row of the fixture is N/A — 'missing' must find it."""
+        result = await find_events({
+            "_session_id": FAKE_SESSION_ID,
+            "signal": "A_KL_RPM",
+            "predicate": "missing",
+            "min_duration_seconds": 0.0,
+        })
+        # Warm-up N/A is a 1-sample event at session start.
+        assert "Events" in result
+        # Either the count is non-zero or "0 of 0" — assert NOT
+        # zero of zero (would mean detector missed the warm-up).
+        assert "0 of 0 found" not in result
+
+    @pytest.mark.asyncio
+    async def test_min_duration_filters_short_events(self) -> None:
+        """min_duration=999s drops every event in a 4-min fixture."""
+        result = await find_events({
+            "_session_id": FAKE_SESSION_ID,
+            "signal": "A_KL_RPM",
+            "predicate": "above_threshold",
+            "threshold": 0.0,
+            "min_duration_seconds": 999.0,
+        })
+        # All events shorter than 999s — none should survive the
+        # filter on a 4-min trip.
+        assert "0 of 0 found" in result or "No events" in result

--- a/docs/plans/2026-05-16-obd-toolset-design.md
+++ b/docs/plans/2026-05-16-obd-toolset-design.md
@@ -1,0 +1,593 @@
+# Design: Agent-Native OBD Investigation Toolset (HARNESS-19)
+
+**Date**: 2026-05-16
+**Status**: Approved
+**Author**: Xiangzhu Yan
+**Ticket**: [HARNESS-19 (#85)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/85)
+**Doc track**: V2 (harness / agent loop)
+
+## Context
+
+The V2 harness has the manual toolset working (`list_manuals`, `get_manual_toc`,
+`read_manual_section`, `search_manual`) and the eval framework is maturing in
+parallel (#74). On the OBD side only one tool exists — `read_obd_data`
+(overview + signal-query modes) — produced by the #69 toolset redesign.
+
+As of 2026-05-09 we also have **one real Yamaha road-test recording** committed
+as a regression fixture: `obd_agent/fixtures/yamaha_dual_road_test_20260508.csv`
+— 4 min 17 s, 257 samples at 1 Hz, dual-channel (K-Line engine ECU +
+CAN ABS ECU), healthy bike, 27 columns including 11 K-Line canonical PIDs and
+16 Yamaha-proprietary `A_YAM_*` fields, plus 2 stored Yamaha-hex DTCs.
+
+With real signal data in hand, it is time to design and scaffold the rest of
+the OBD-side toolset — clean-slate, not a port of the V1 deterministic
+pipeline.
+
+## Problem
+
+`read_obd_data` covers only the discovery + raw-window-read pair of cognitive
+primitives. An agent investigating real OBD data also needs:
+
+1. **Aggregation primitives** — without them, the agent burns tokens pulling
+   raw rows and doing arithmetic LLMs are unreliable at.
+2. **Event-finding primitives** — Grep-style "when does this signal meet this
+   condition?" — collapses 257 raw samples into a handful of useful windows.
+3. **DTC-specific tools** — the fixture has 2 stored DTCs in Yamaha hex format
+   (`87F11043…`), but no list/lookup/decode tools exist. Today the agent sees
+   raw hex strings with no path forward.
+4. **A_YAM_\* proprietary signals exposure** — `format_normalizer.py` strips
+   all `A_YAM_*` fields, losing ~60% of the Yamaha fixture's signal richness
+   (battery voltage, injection pulse, cylinder head temp, etc.).
+5. **A specialist sub-agent** — the manual side has `manual_agent.py` doing
+   focused work for the eval suite; the OBD side has nothing analogous, so the
+   main agent must do all OBD investigation in its own context.
+
+The toolset must be **agent-native**: tools provide *data*, not pre-digested
+conclusions. The V1 pipeline's `generate_clues` /`detect_anomalies` /
+`statistics_extractor` chain runs before the LLM in V1; for V2 the agent
+drives the investigation itself.
+
+## Requirements
+
+1. Six OBD investigation primitives mapped to distinct cognitive steps
+   (discover, read, aggregate, find-events, list-DTCs, lookup-DTC).
+2. A new OBD sub-agent (`run_obd_agent`) mirroring the established
+   `manual_agent.py` template — restricted toolset, structured-output
+   contract, no SSE / event-log persistence.
+3. Two delegation wrappers (`delegate_to_obd_agent`,
+   `delegate_to_manual_agent`) so the main agent can route compound
+   inquiries to specialists (hybrid Pattern 2, see §Approach).
+4. Tools must expose `A_YAM_*` proprietary signals under their original
+   column names.
+5. DTC tools must handle Yamaha-proprietary hex codes honestly: no
+   fabricated decodings; manual-search pivot for unknown formats.
+6. All tools return text (no multimodal — OBD data is tabular).
+7. Hermetic unit tests against the real Yamaha fixture; no network or LLM
+   calls. Smoke-tested sub-agent loop with mocked `LLMClient`.
+
+## Out of scope
+
+The following are deliberately deferred to follow-up tickets:
+
+- **Diagnostic accuracy benchmarks** — no labelled fault data exists yet.
+- **OBD golden set + eval harness** (parallel to #73 for manuals) — needs a
+  separate HARNESS-XX ticket once goldens can be generated.
+- **Cross-signal correlation tool** (`correlate_signals`) — agent can
+  approximate by reading two windows and reasoning; add only if evals show
+  it is needed.
+- **Anomaly-detection-as-a-tool** — would re-introduce the "pre-digested
+  analysis" pattern that #69 walked away from. May revisit later as a
+  derived-feature primitive (changepoint timestamps as *data*, not
+  conclusions).
+- **Annotation scratchpad** — useful for long sessions but introduces state
+  (where it lives, when it clears).
+- **Freeze-frame snapshot tool** — current fixture has no freeze-frame data.
+  Defer until a fixture exists.
+- **Real-time / streaming OBD ingestion**.
+- **Multi-vehicle generalisation** — Yamaha-first; Honda / others later.
+- **Yamaha-hex DTC decoder** — no public spec; reverse-engineering is its
+  own workstream.
+
+## Approach
+
+### Architectural pattern: hybrid (Pattern 2)
+
+Three patterns were considered:
+
+| Pattern | Main agent toolbox | Sub-agents in production? |
+|---|---|---|
+| 1 — Flat | All primitives directly | No (eval-only) |
+| **2 — Hybrid (chosen)** | **Primitives + delegation wrappers** | **Yes, via `delegate_to_*`** |
+| 3 — Pure delegation | Only delegation wrappers | Yes (primitives hidden from main) |
+
+Pattern 2 matches Claude Code's own design (it has `Read` / `Grep` / `Glob`
+*and* the `Task` sub-agent tool). The main agent does small things directly
+("what's the RPM range?") and delegates compound investigations
+("investigate the stored DTCs end-to-end").
+
+Pattern 3 is cleaner architecturally but rewrites the main agent's prompt in
+the same PR — too much risk in one change. Pattern 1 leaves sub-agents
+aspirational. Pattern 2 lands meaningful delegation without forcing a
+whole-architecture rewrite.
+
+### Tool decomposition philosophy
+
+Per Anthropic's *Writing tools for agents* guide and the manual-toolset
+precedent: each tool maps to one cognitive step. We split `read_obd_data`'s
+current two-mode shape (overview vs. signal-query) into separate tools
+(`list_signals` + `read_window`) so the agent never juggles modes within a
+single call.
+
+Tool-name analogs from Claude Code's own primitives:
+
+| Claude Code | OBD analog | Why |
+|---|---|---|
+| `Glob` | `list_signals(pattern, subsystem)` | discovery — what exists |
+| `Read` | `read_window(signals, t1, t2)` | targeted sample read |
+| `Grep` | `find_events(signal, predicate)` | where does condition hold |
+| (aggregate) | `get_signal_stats(signals, range)` | summary without raw rows |
+| (lookup) | `list_dtcs(status, ecu)` + `lookup_dtc(code)` | DTC drilldown |
+
+### Yamaha-specific decisions
+
+| Quirk | Decision | Rationale |
+|---|---|---|
+| `A_YAM_*` proprietary fields stripped by normalizer | Expose under **original names** (no friendly aliases yet) | Zero new mapping work; agent calls `search_manual` to learn what each means; revisit if evals show stumbling |
+| Yamaha-hex DTCs (`87F11043…`) | **Honest no-decoder + manual pivot** in `lookup_dtc` | No public Yamaha DTC spec; building a decoder is out of scope; manual chart is the realistic recovery path |
+| Channel B (ABS ECU) not materialized in fixture | List as `not present` in `list_signals`; `list_dtcs(ecu="abs")` returns empty cleanly | Future fixtures may include Channel B; interface stable |
+| Freeze-frame data absent | Skip `get_freeze_frame` tool entirely | Defer interface until data exists; lying about an unavailable tool is worse than omitting it |
+
+## Design
+
+### 1. Architecture
+
+```
+                   ┌───────────────────────────────┐
+                   │   Main diagnosis agent        │
+                   │   (12-tool registry)          │
+                   │   primitives + delegation     │
+                   └──────────────┬────────────────┘
+                                  │ delegate_to_obd_agent(inquiry)
+                                  ▼
+┌───────────────────────────────────────────────────────────────┐
+│  OBD sub-agent  (new — app/harness_agents/obd_agent.py)       │
+│  • run_obd_agent(inquiry, session_id, deps) -> OBDAgentResult │
+│  • Restricted ReAct loop, max_iter=8, timeout=120s            │
+│  • Reuses LLMClient + ToolRegistry from app.harness           │
+└──────────────┬────────────────────────────────────────────────┘
+               │  tool calls (only the 6 OBD primitives)
+               ▼
+┌───────────────────────────────────────────────────────────────┐
+│  OBD investigation toolset  (new — app/harness_tools/obd_*.py)│
+│  ├─ list_signals       (Glob analog)                          │
+│  ├─ read_window        (Read analog)                          │
+│  ├─ get_signal_stats   (aggregate primitive)                  │
+│  ├─ find_events        (Grep analog)                          │
+│  ├─ list_dtcs          (DTC enumeration)                      │
+│  └─ lookup_dtc         (DTC decode + manual pivot)            │
+└──────────────┬────────────────────────────────────────────────┘
+               │  reads raw CSV via _resolve_log_path() pattern
+               ▼
+       OBDAnalysisSession.raw_input_file_path on disk
+```
+
+#### Registries (three independent factories)
+
+```python
+create_default_registry()    # Main agent: 12 tools
+                              #   6 OBD primitives + 4 manual primitives
+                              #   + delegate_to_obd_agent
+                              #   + delegate_to_manual_agent
+
+create_obd_agent_registry()  # OBD sub-agent: 6 primitives only
+                              #   (no delegation — prevents recursion)
+
+create_manual_agent_registry() # Manual sub-agent: 3 primitives only
+                                #   (already exists in manual_agent.py)
+```
+
+#### `OBDAgentResult` contract
+
+Mirrors `ManualAgentResult` (`harness_agents/types.py`) where structurally
+identical, diverges only where OBD data differs from manual content.
+
+```python
+class SignalCitation(BaseModel):
+    signal: str
+    time_range: Optional[Tuple[str, str]] = None  # ISO start / end
+    value: Optional[float] = None
+    stat: Optional[str] = None                    # "p95"|"mean"|"max"|...
+    units: Optional[str] = None
+
+class DTCCitation(BaseModel):
+    code: str
+    status: Literal["stored", "pending"]
+    ecu: Optional[str] = None
+
+class DataExcerpt(BaseModel):
+    kind: Literal["stats", "events", "window", "dtcs"]
+    payload: Dict[str, Any]                        # tool-output shape
+
+class OBDAgentResult(BaseModel):
+    summary: str
+    signal_citations: List[SignalCitation]
+    dtc_citations: List[DTCCitation]
+    raw_data: List[DataExcerpt]
+    limitations: List[str]
+    tool_trace: List[ToolCallTrace]                # reused from types.py
+    iterations: int
+    total_tokens: int
+    stopped_reason: StoppedReason                  # reused from types.py
+```
+
+### 2. Tool catalog
+
+All 8 tools return plain text. Inputs are Pydantic-validated; `_session_id` is
+auto-injected by the loop and not declared in the input model.
+
+#### 2.1 `list_signals` (Glob analog, cheap)
+
+**Question:** *"What signals does this OBD log contain?"*
+
+```python
+class ListSignalsInput(BaseModel):
+    pattern: Optional[str] = None
+    subsystem: Optional[Literal["engine", "abs", "all"]] = "all"
+```
+
+Returns ~150-token text inventory: time range, sampling rate, channel
+presence, signal list with units + density (dense / sparse / missing).
+Filters by glob-ish pattern and subsystem.
+
+#### 2.2 `read_window` (Read analog, medium)
+
+**Question:** *"Give me raw samples for these signals in this time range."*
+
+```python
+class ReadWindowInput(BaseModel):
+    signals: List[str] = Field(..., min_length=1, max_length=8)
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    max_rows: int = Field(default=50, ge=1, le=500)
+```
+
+Tab-separated table with timestamp + requested signals. Auto-downsamples
+when window samples exceed `max_rows`. Always shows units + missing-data
+notes.
+
+#### 2.3 `get_signal_stats` (aggregate, cheap)
+
+**Question:** *"Summarize these signals — give me mean/std/percentiles, no
+raw rows."*
+
+```python
+class GetSignalStatsInput(BaseModel):
+    signals: List[str] = Field(..., min_length=1, max_length=10)
+    time_range: Optional[Tuple[str, str]] = None
+    include: Optional[List[Literal[
+        "basic", "percentiles", "trend", "extrema",
+    ]]] = None  # default ["basic", "percentiles"]
+```
+
+Internal implementation **reuses `obd_agent/statistics_extractor.py`** — the
+kind of "primitive helper" #69 wanted preserved (data-producing, not
+conclusion-emitting). With `include=["extrema"]` also returns timestamps of
+min/max — useful for the agent to drill in with `read_window`.
+
+#### 2.4 `find_events` (Grep analog, cheap)
+
+**Question:** *"When does this signal meet this condition?"*
+
+```python
+class FindEventsInput(BaseModel):
+    signal: str
+    predicate: Literal[
+        "above_threshold", "below_threshold",
+        "rising_above", "falling_below",
+        "rate_of_change_above", "rate_of_change_below",
+        "missing",
+    ]
+    threshold: Optional[float] = None
+    min_duration_seconds: float = 1.0
+    merge_gap_seconds: float = 2.0
+    time_range: Optional[Tuple[str, str]] = None
+    max_events: int = Field(default=20, ge=1, le=100)
+```
+
+Returns list of `(start, end, duration, peak, sample_count)` per event.
+Predicates are a fixed enum (safer, more predictable, easier to test) — no
+free-form expressions.
+
+#### 2.5 `list_dtcs` (DTC enumeration, cheap)
+
+**Question:** *"What fault codes are in this session?"*
+
+```python
+class ListDTCsInput(BaseModel):
+    status: Optional[Literal["stored", "pending", "all"]] = "all"
+    ecu: Optional[Literal["engine", "abs", "all"]] = "all"
+```
+
+Extracts standard P-codes from `GET_DTC` / `GET_CURRENT_DTC` columns (existing
+`_parse_dtc_list` path) **and** Yamaha-hex DTCs from the leading metadata
+comment block (new helper). Groups by classification, separates stored vs.
+pending.
+
+#### 2.6 `lookup_dtc` (DTC decode, cheap)
+
+**Question:** *"What does this fault code mean, what subsystem is it about,
+what should I look at next?"*
+
+```python
+class LookupDTCInput(BaseModel):
+    code: str
+```
+
+Standard P/C/B/U codes → python-OBD lookup (existing
+`log_parser.py:159` path). Yamaha hex → honest "no decoder" output with a
+`search_manual(query=<code>, vehicle_model=…)` pivot. Unknown formats → clear
+error string suggesting verification.
+
+#### 2.7 `delegate_to_obd_agent` (delegation wrapper)
+
+**Question (from main agent):** *"Investigate this OBD-related question
+end-to-end; come back with a structured finding."*
+
+```python
+class DelegateToOBDAgentInput(BaseModel):
+    inquiry: str = Field(..., min_length=10, max_length=500)
+```
+
+Handler:
+1. Build `OBDAgentDeps(llm_client, create_obd_agent_registry(), config)`.
+2. Await `run_obd_agent(inquiry, _session_id, deps)` → `OBDAgentResult`.
+3. Serialize via `format_obd_agent_result(result)` → structured markdown
+   (summary + signal_citations + dtc_citations + raw_data + limitations).
+
+`max_result_chars` raised to ~80 KB to accommodate sub-agent outputs.
+
+#### 2.8 `delegate_to_manual_agent` (delegation wrapper)
+
+```python
+class DelegateToManualAgentInput(BaseModel):
+    inquiry: str = Field(..., min_length=10, max_length=500)
+    obd_context: Optional[str] = Field(default=None, max_length=2000)
+```
+
+Pure wrapper over the existing `run_manual_agent` infrastructure. Same
+serialization pattern with `format_manual_agent_result`.
+
+### 3. Data flow + infrastructure
+
+#### 3.1 Raw-data access (no new infrastructure)
+
+Reuse `_resolve_log_path(session_id, db)` + `parse_log_file(path)` already in
+the codebase. Each tool re-parses the CSV on call. Justified for v1 because
+the Yamaha fixture is 257 rows / ~50 KB and parses in < 50 ms. If profiling
+shows it matters, add a per-sub-agent-run `lru_cache` later — single PR,
+no architectural debt.
+
+#### 3.2 `A_YAM_*` field exposure
+
+The new tools **bypass `format_normalizer.py`** (which strips these). They
+read column names directly from `parse_log_file()` output. A new helper
+`obd_signal_inventory.py` produces `SignalDescriptor(name, units, subsystem,
+density)` records. Units for known `A_YAM_*` fields come from a small
+hand-curated dict (`BATT_V` → V, `INJ_MS` → ms, etc.); unknown fields just
+say "raw".
+
+#### 3.3 DTC parsing
+
+```
+list_dtcs / lookup_dtc
+  └─> _extract_dtcs_from_metadata(file_path)  [new helper]
+        ├─ Regex over leading comment block for "Stored DTC:" / "Pending DTC:"
+        │  (Yamaha hex lives there in the fixture)
+        └─ Existing _parse_dtc_list() for GET_DTC / GET_CURRENT_DTC columns
+           (standard P-code path)
+  └─> _classify_dtc(code) → "standard" | "yamaha_hex" | "unknown"
+        ├─ standard → python-OBD table
+        ├─ yamaha_hex → honest no-decoder output
+        └─ unknown → actionable error string
+```
+
+#### 3.4 Sub-agent execution context
+
+Sub-agent **shares the LLMClient** with the main agent (same OpenRouter /
+Ollama backend) but uses an **independent message history** and **restricted
+tool registry**. Failure isolation: a sub-agent timeout returns a graceful
+`OBDAgentResult(stopped_reason="timeout", …)` rather than bubbling up.
+
+#### 3.5 Result formatters
+
+New file `app/harness_agents/result_formatters.py`:
+- `format_obd_agent_result(result) -> str` — markdown serialization for
+  delegation tool output.
+- `format_manual_agent_result(result) -> str` — same for manual.
+
+Lives next to the agent files because it is semantically owned by the
+sub-agent contract, not the tool.
+
+#### 3.6 What does NOT change
+
+- `app/harness/loop.py` — main loop logic unchanged; just sees more tools.
+- `app/harness/context.py` — truncation / compaction logic unchanged.
+- `app/harness/autonomy.py` — tier routing unchanged.
+- `app/harness_agents/manual_agent.py` — manual sub-agent unchanged.
+- DB schema — unchanged.
+- API endpoints — unchanged. (No new standalone OBD sub-agent endpoint in
+  this PR; can be added later when an OBD eval suite exists.)
+
+### 4. Error handling
+
+Anthropic's tool-writing guide is emphatic that errors must be **actionable**.
+Three tiers:
+
+| Tier | Cause | Handler | Example output |
+|---|---|---|---|
+| **T1 — Input validation** | Pydantic rejects the call | Registry catches `ValidationError`, formats into actionable string | "predicate 'above_threshold' requires `threshold` parameter. Example: …" |
+| **T2 — Domain mismatch** | Valid input, signal/code doesn't exist | Tool handler returns descriptive text (NOT raises); `is_error=False` | "Signal 'EGT' not in this session. Did you mean: COOLANT_TEMP, IAT? Use `list_signals` to see all 15 available signals." |
+| **T3 — System / IO failure** | DB unreachable, file missing, sub-agent timeout | Tool handler raises → registry catches → `ToolResult(is_error=True, …)` | "Error: could not read OBD log file for session 7f3b… (file not found). This may be a stale session ID; verify with the user." |
+
+#### Per-tool edge cases (summary)
+
+- **`list_signals`**: corrupt file → informational message, not error.
+- **`read_window`**: unknown signal → fuzzy-match suggestion (Levenshtein over
+  inventory); inverted window → clear message; window outside session
+  bounds → 0-sample notice with session range.
+- **`get_signal_stats`**: <3 valid samples → omit `autocorr` / `linreg` with
+  notes; all N/A in range → `count=0` row (not dropped).
+- **`find_events`**: zero events → include max value in range to help agent
+  adjust threshold; missing threshold for value predicate → T1.
+- **`list_dtcs`**: no DTCs → informational, not error.
+- **`lookup_dtc`**: Yamaha hex → no-decoder output with manual pivot;
+  unrecognized format → "Code 'X1234' is not a recognized OBD-II standard
+  code and does not match Yamaha hex format. Verify the code…"
+- **`delegate_to_*`**: timeout / max_iterations → structured `*AgentResult`
+  with `stopped_reason` set; LLM error → `stopped_reason="error"`.
+
+#### Sub-agent loop error handling
+
+Mirror `manual_agent.py`'s pattern verbatim:
+
+| Failure | Handling |
+|---|---|
+| `asyncio.timeout` | Catch → `stopped_reason="timeout"`, preserve partial state |
+| Max iterations | While-else → `stopped_reason="max_iterations"` |
+| LLM JSON parse failure | Fallback: `_extract_last_assistant_content`, empty citations |
+| Tool exec error | Surface error string via registry; sub-agent keeps iterating |
+| Tool argument parse error | Append clean error as tool result so LLM self-corrects |
+
+#### Privacy boundary
+
+Per CLAUDE.md "Privacy & Data Boundaries (Non-Negotiable)":
+
+- `read_window` enforces `max_rows ≤ 500` via Pydantic — prevents log dump.
+- `get_signal_stats` only returns aggregates.
+- `find_events` returns event metadata (start / end / peak), never the
+  underlying sample sequences.
+- `OBDAgentResult.raw_data` excerpts are bounded by the same caps because
+  they are built from these tool outputs.
+
+VINs: existing `pseudonymise_vin()` policy still applies but is dormant on
+this hot path per APP-54. No new handling required.
+
+### 5. Testing strategy
+
+Per issue #85: "Smoke-test all tools against the real road-test fixture.
+Tool registration in the harness, basic unit tests." Diagnostic-accuracy
+evals are out of scope.
+
+#### 5.1 Three test layers
+
+| Layer | What it tests | Where | Network / LLM? |
+|---|---|---|---|
+| Unit | Each tool against the Yamaha fixture | `tests/harness_tools/test_obd_*.py` | No |
+| Sub-agent smoke | `run_obd_agent` end-to-end with mocked LLM | `tests/harness_agents/test_obd_agent.py` | No |
+| Delegation smoke | `delegate_to_*` handlers wired into the registry | `tests/harness_tools/test_delegation_tools.py` | No |
+
+#### 5.2 Coverage targets (~35-40 new tests)
+
+- `test_obd_signals.py` — 5 classes (List/Read/Stats/Events/Inventory)
+- `test_obd_dtcs.py` — 2 classes (List / Lookup)
+- `test_obd_agent.py` — sub-agent ReAct flow, timeout, max_iter, JSON
+  failure, tool-error recovery
+- `test_delegation_tools.py` — registry dispatch, session_id injection,
+  formatted output, recursion guard (sub-agent registry MUST NOT contain
+  delegation tools)
+
+Specific must-have unit tests:
+
+- `test_list_signals_returns_a_yam_proprietary_signals_under_original_names`
+  — validates locked decision.
+- `test_list_dtcs_extracts_two_yamaha_hex_dtcs_from_fixture_metadata` —
+  uses real fixture data.
+- `test_lookup_dtc_yamaha_hex_returns_no_decoder_with_manual_pivot` —
+  validates locked decision.
+- `test_read_window_unknown_signal_returns_fuzzy_match_suggestion` —
+  T2 validation.
+- `test_get_signal_stats_basic_stats_match_statistics_extractor_output` —
+  reuse verification.
+- `test_no_recursion_obd_agent_cannot_call_delegate_tool` — registry
+  isolation.
+
+#### 5.3 What is NOT tested in this PR
+
+- **Diagnostic accuracy / correctness of agent conclusions** — out of scope.
+- **Production main-agent integration regression** — covered by existing
+  `test_integration.py` and `test_e2e_agent.py`. Run as-is; fix any fallout
+  from the main registry growing from 5 to 12 tools.
+- **Performance** — Yamaha fixture is small; defer caching decisions.
+- **Multi-vehicle generalization** — Yamaha-only.
+
+## Files to create / modify
+
+| File | Action | LOC est. |
+|---|---|---|
+| `app/harness_agents/obd_agent.py` | Create — sub-agent ReAct loop | ~600 |
+| `app/harness_agents/obd_agent_prompts.py` | Create — system prompt + user message | ~120 |
+| `app/harness_agents/types.py` | Modify — add `SignalCitation`, `DTCCitation`, `DataExcerpt`, `OBDAgentResult` | +60 |
+| `app/harness_agents/result_formatters.py` | Create — `format_obd_agent_result`, `format_manual_agent_result` | ~150 |
+| `app/harness_tools/obd_signals.py` | Create — 4 signal tools | ~500 |
+| `app/harness_tools/obd_dtcs.py` | Create — 2 DTC tools | ~250 |
+| `app/harness_tools/obd_signal_inventory.py` | Create — `SignalDescriptor` + classifier helpers | ~120 |
+| `app/harness_tools/delegation_tools.py` | Create — `delegate_to_obd_agent` + `delegate_to_manual_agent` | ~180 |
+| `app/harness_tools/input_models.py` | Modify — 6 OBD input models + 2 delegation input models | +120 |
+| `app/harness/tool_registry.py` | Modify — `create_default_registry` swap, new `create_obd_agent_registry` | +50 |
+| `app/harness/harness_prompts.py` | Modify — tool descriptions + delegation guidance | +60 |
+| `app/harness_tools/obd_data_tools.py` | Modify — unregister `read_obd_data` from default registry; keep file for one cycle | -10 |
+| `tests/harness_tools/test_obd_signals.py` | Create | ~400 |
+| `tests/harness_tools/test_obd_dtcs.py` | Create | ~200 |
+| `tests/harness_tools/test_delegation_tools.py` | Create | ~200 |
+| `tests/harness_agents/test_obd_agent.py` | Create | ~350 |
+
+Net addition: ~3,200 LOC including tests.
+
+## Open questions / future work
+
+These are deliberately deferred to follow-up tickets but worth recording:
+
+1. **`delegate_to_obd_agent` vs. direct OBD tools — when does main agent
+   pick which?** Initial system-prompt guidance: "Use primitive tools for
+   focused questions; delegate for compound investigations." If
+   in-production traces show the main agent over- or under-delegating, tune
+   the prompt or surface confidence-based routing.
+
+2. **Per-run DataFrame cache.** Single PR refactor when profiling shows
+   per-call CSV parsing is the bottleneck.
+
+3. **Yamaha-hex DTC decoder.** Needs Yamaha spec or careful reverse-engineering.
+   Until then, `lookup_dtc` honestly says "no decoder; check the manual."
+
+4. **OBD eval suite.** Parallel to #73 for manuals. Blocked on having
+   labelled fault data — pending real-world cases from the PolyU pilot.
+
+5. **A_YAM_\* friendly aliases.** If evals show the agent stumbles on
+   proprietary field names (e.g. confusing `A_YAM_VVA` with valve angle vs.
+   variable valve actuator), build a friendly-name map. Otherwise the
+   agent calls `search_manual` to learn what each means.
+
+6. **Main agent → pure-orchestrator rewrite (Pattern 3).** Long-term
+   direction. Triggered when delegation traces show the main agent rarely
+   uses primitives directly. Separate ticket.
+
+7. **Freeze-frame tool.** Once a fixture with freeze-frame data exists,
+   add `get_freeze_frame(dtc_code?)`.
+
+8. **Channel B (ABS ECU) data.** Currently `list_signals` reports "not
+   present" for the Yamaha fixture. When CAN-side data appears in future
+   uploads, the existing tools should handle it transparently.
+
+## References
+
+- Issue [#85 — HARNESS-19 (this ticket)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/85)
+- Issue [#69 — V2 toolset redesign (`read_obd_data` lineage)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/69)
+- Issue [#71 — Manual toolset (reference pattern for 3-tool decomposition)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/71)
+- Issue [#73 — Manual sub-agent eval suite (`ManualAgentResult` contract)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/73)
+- Issue [#80 — Yamaha real-road-test regression fixture](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/80)
+- Issue [#26 — Harness engineering architecture](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/26)
+- [Anthropic — Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)
+- [Anthropic — Develop your tests](https://platform.claude.com/docs/en/test-and-evaluate/develop-tests)
+- `app/harness_agents/manual_agent.py` — template for the OBD sub-agent
+- `docs/v2_design_doc.md` — V2 architecture (will be updated when this PR lands)
+- `docs/v2_dev_plan.md` — V2 dev plan (HARNESS-19 ticket entry will be added)


### PR DESCRIPTION
## Summary

Third in the 5-PR chain. Adds the six decomposed cognitive primitives the OBD sub-agent (PR 4) and the main agent (PR 5) will use.

Base: #92 (PR 2 in the chain).

## The six primitives

Mapped to Claude Code's own tool shape:

| Tool | Claude Code analog | Agent question |
|---|---|---|
| \`list_signals\` | Glob | What signals exist? |
| \`read_window\` | Read | Give me samples in this time range. |
| \`get_signal_stats\` | (aggregate) | Summarize min/max/p95/std without raw rows. |
| \`find_events\` | Grep | When does signal X meet condition Y? |
| \`list_dtcs\` | (enumeration) | What fault codes are present? |
| \`lookup_dtc\` | (decode) | What does this code mean? |

Tools are exported as \`ToolDefinition\`s here but **not yet registered** in the default registry — that lands in PR 5 alongside the delegation wiring.

## Locked design decisions exercised

- **Yamaha hex DTCs**: \`lookup_dtc(\"87F11043...\")\` returns honest \"no decoder available\" + \`search_manual\` pivot. No fabricated decodings.
- **Fuzzy errors**: unknown signal names get suggestions (\`Signal 'EGT' not in this session. Did you mean: COOLANT_TEMP, IAT?\`).
- **Threshold required for value predicates**: \`find_events(signal='RPM', predicate='above_threshold')\` without threshold returns a T1 validation error with an example.
- **No-event \"max in range\" anchor**: \`find_events\` on an impossibly high threshold tells the agent what the actual max was, so it knows how to adjust.

## Test plan

- [x] 63 unit tests (39 signals + 24 DTCs).
- [x] Reference-value tests confirm stats match direct computation (\`test_basic_stats_match_reference\`).
- [x] Yamaha-hex \"no decoder\" path verified (\`TestLookupDTCYamahaHex\`).
- [x] All A_YAM_* signals get stats and surface in \`list_signals\` (\`test_a_yam_signals_listed_under_original_names\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)