### PR TITLE
HARNESS-19 [2/5]: Yamaha-aware OBD loader + signal inventory (re-opened)

### DIFF
--- a/diagnostic_api/app/harness_agents/types.py
+++ b/diagnostic_api/app/harness_agents/types.py
@@ -14,7 +14,7 @@ Author: Li-Ta Hsu
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -97,6 +97,108 @@ class ManualAgentResult(BaseModel):
     summary: str
     citations: List[Citation] = Field(default_factory=list)
     raw_sections: List[SectionRef] = Field(default_factory=list)
+    tool_trace: List[ToolCallTrace] = Field(default_factory=list)
+    iterations: int = 0
+    total_tokens: int = 0
+    stopped_reason: StoppedReason = "complete"
+
+
+# ── OBD sub-agent types ───────────────────────────────────────────
+
+
+class SignalCitation(BaseModel):
+    """One signal/timestamp reference produced by the OBD sub-agent.
+
+    Parallel to ``Citation`` for the manual sub-agent — same role but
+    addresses time-series data rather than manual prose.
+
+    Attributes:
+        signal: Signal/column name (e.g. ``RPM`` or
+            ``A_YAM_INJ_MS``).
+        time_range: Optional ISO start/end the citation refers to.
+            Omitted for whole-session references.
+        value: Optional point or statistic value.
+        stat: Name of the statistic when ``value`` is an aggregate
+            (e.g. ``"p95"``, ``"mean"``, ``"max"``).
+        units: Engineering units for ``value``.
+    """
+
+    signal: str
+    time_range: Optional[Tuple[str, str]] = None
+    value: Optional[float] = None
+    stat: Optional[str] = None
+    units: Optional[str] = None
+
+
+class DTCCitation(BaseModel):
+    """One DTC reference produced by the OBD sub-agent.
+
+    Attributes:
+        code: DTC code string — either standard P/C/B/U format
+            (e.g. ``"P0117"``) or Yamaha-proprietary raw hex
+            (e.g. ``"87F11043000000000000CB"``).
+        status: Whether the code is stored or pending.
+        ecu: Originating ECU label (e.g. ``"K-Line"``,
+            ``"CAN-ABS"``).
+    """
+
+    code: str
+    status: Literal["stored", "pending"]
+    ecu: Optional[str] = None
+
+
+DataExcerptKind = Literal["stats", "events", "window", "dtcs"]
+"""Tag for the kind of tool output preserved in ``DataExcerpt``."""
+
+
+class DataExcerpt(BaseModel):
+    """Verbatim tool-output block the OBD sub-agent pulled.
+
+    Used so the main agent can quote the sub-agent's evidence
+    directly rather than re-deriving it.  ``payload`` preserves the
+    shape of the tool's output dict — schema varies per ``kind``.
+
+    Attributes:
+        kind: Which tool produced this excerpt.
+        payload: Tool-output content (stats dict, event list,
+            window samples, DTC entry).
+    """
+
+    kind: DataExcerptKind
+    payload: Dict[str, Any]
+
+
+class OBDAgentResult(BaseModel):
+    """Full output of one OBD-agent run.
+
+    Mirrors ``ManualAgentResult`` where structurally identical and
+    diverges where OBD data shape requires it.  Two citation lists
+    (signal + DTC) instead of one polymorphic list — signals and
+    DTCs live in different conceptual spaces.  ``limitations`` is
+    additive: the OBD sub-agent frequently needs to flag missing
+    data (Channel B not present, Yamaha-hex not decodable,
+    freeze-frame absent) for the main agent.
+
+    Attributes:
+        summary: 3-5 sentence answer to the inquiry.
+        signal_citations: Signal/time-range references.
+        dtc_citations: DTC references.
+        raw_data: Tool-output excerpts the main agent can quote.
+        limitations: Concrete reasons something could not be
+            answered (e.g. ``"Yamaha hex DTC not decodable"``).
+        tool_trace: Ordered list of tool invocations.
+        iterations: ReAct cycles consumed.
+        total_tokens: Approximate input + output token total.
+        stopped_reason: Why the loop ended.
+    """
+
+    summary: str
+    signal_citations: List[SignalCitation] = Field(
+        default_factory=list,
+    )
+    dtc_citations: List[DTCCitation] = Field(default_factory=list)
+    raw_data: List[DataExcerpt] = Field(default_factory=list)
+    limitations: List[str] = Field(default_factory=list)
     tool_trace: List[ToolCallTrace] = Field(default_factory=list)
     iterations: int = 0
     total_tokens: int = 0

--- a/diagnostic_api/app/harness_tools/input_models.py
+++ b/diagnostic_api/app/harness_tools/input_models.py
@@ -11,7 +11,7 @@ never sees or passes it.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Literal, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -142,5 +142,290 @@ class ReadManualSectionInput(BaseModel):
         default=True,
         description=(
             "Include child subsections in the result."
+        ),
+    )
+
+
+# ── OBD investigation primitives (HARNESS-19) ────────────────────
+
+
+class ListSignalsInput(BaseModel):
+    """Input for the list_signals tool.
+
+    Discovery primitive — answers 'what signals does this OBD log
+    contain?' before any reading.  Cheap.
+    """
+
+    pattern: Optional[str] = Field(
+        default=None,
+        description=(
+            "Glob-style filter on signal name (case-insensitive). "
+            "Examples: '*TEMP*', 'A_YAM_*', 'RPM'. "
+            "Omit to list all signals."
+        ),
+    )
+    subsystem: Literal["engine", "abs", "all"] = Field(
+        default="all",
+        description=(
+            "Filter by ECU subsystem. 'engine' = K-Line engine "
+            "ECU (Channel A). 'abs' = CAN ABS ECU (Channel B). "
+            "Defaults to 'all'."
+        ),
+    )
+
+
+class ReadWindowInput(BaseModel):
+    """Input for the read_window tool.
+
+    Targeted sample read for one or more signals in a time window,
+    with auto-downsampling.  Medium token cost.
+    """
+
+    signals: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=8,
+        description=(
+            "Signal/column names to read (e.g. ['RPM', "
+            "'COOLANT_TEMP', 'A_YAM_INJ_MS']). 1-8 signals per "
+            "call. Use list_signals first to discover available "
+            "names."
+        ),
+    )
+    start_time: Optional[str] = Field(
+        default=None,
+        description=(
+            "Start of time window (ISO format, e.g. "
+            "'2026-05-08T11:21:30'). Omit to read from session "
+            "start."
+        ),
+    )
+    end_time: Optional[str] = Field(
+        default=None,
+        description=(
+            "End of time window (ISO format). Omit to read to "
+            "session end."
+        ),
+    )
+    max_rows: int = Field(
+        default=50,
+        ge=1,
+        le=500,
+        description=(
+            "Max sample rows to return. If the window has more "
+            "samples than this, the tool evenly downsamples. "
+            "Hard cap 500 (privacy boundary)."
+        ),
+    )
+
+
+_STATS_INCLUDE_T = Literal[
+    "basic", "percentiles", "trend", "extrema",
+]
+
+
+class GetSignalStatsInput(BaseModel):
+    """Input for the get_signal_stats tool.
+
+    Aggregate primitive — summary statistics without raw samples.
+    Cheap. Reuses obd_agent.statistics_extractor under the hood.
+    """
+
+    signals: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description=(
+            "Signal names to summarize (1-10 per call)."
+        ),
+    )
+    time_range: Optional[Tuple[str, str]] = Field(
+        default=None,
+        description=(
+            "Optional (start, end) ISO timestamps. Omit for "
+            "full session."
+        ),
+    )
+    include: Optional[List[_STATS_INCLUDE_T]] = Field(
+        default=None,
+        description=(
+            "Which stat groups to include. Choose from "
+            "'basic' (min/max/mean/std/count), "
+            "'percentiles' (p5/p25/p50/p75/p95), "
+            "'trend' (linreg_slope, autocorr_lag1), "
+            "'extrema' (timestamps of min and max). "
+            "Default: ['basic', 'percentiles']."
+        ),
+    )
+
+
+_EVENT_PREDICATE_T = Literal[
+    "above_threshold",
+    "below_threshold",
+    "rising_above",
+    "falling_below",
+    "rate_of_change_above",
+    "rate_of_change_below",
+    "missing",
+]
+
+
+class FindEventsInput(BaseModel):
+    """Input for the find_events tool.
+
+    Grep-of-time-series. Returns (start, end, peak) tuples for
+    windows where the predicate holds.  Cheap.
+    """
+
+    signal: str = Field(
+        ...,
+        description="Signal name to scan.",
+    )
+    predicate: _EVENT_PREDICATE_T = Field(
+        ...,
+        description=(
+            "Condition to find. "
+            "'above_threshold'/'below_threshold' require "
+            "threshold parameter. "
+            "'rising_above'/'falling_below' require threshold; "
+            "match only at crossings (first sample where signal "
+            "crosses from one side to the other). "
+            "'rate_of_change_above'/'rate_of_change_below' "
+            "require threshold and operate on finite differences "
+            "(value units per second). "
+            "'missing' finds N/A windows; threshold ignored."
+        ),
+    )
+    threshold: Optional[float] = Field(
+        default=None,
+        description=(
+            "Threshold value (required for all predicates "
+            "except 'missing')."
+        ),
+    )
+    min_duration_seconds: float = Field(
+        default=1.0,
+        ge=0.0,
+        description=(
+            "Drop events shorter than this. Useful for "
+            "filtering single-sample spikes."
+        ),
+    )
+    merge_gap_seconds: float = Field(
+        default=2.0,
+        ge=0.0,
+        description=(
+            "Merge adjacent events whose gap is below this "
+            "duration. 0 disables merging."
+        ),
+    )
+    time_range: Optional[Tuple[str, str]] = Field(
+        default=None,
+        description=(
+            "Optional (start, end) ISO timestamps. Omit for "
+            "full session."
+        ),
+    )
+    max_events: int = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description=(
+            "Max events to return (most recent if more match)."
+        ),
+    )
+
+
+class ListDTCsInput(BaseModel):
+    """Input for the list_dtcs tool.
+
+    Enumerates fault codes in the session. Surfaces standard
+    P/C/B/U codes and Yamaha-proprietary hex codes.  Cheap.
+    """
+
+    status: Literal["stored", "pending", "all"] = Field(
+        default="all",
+        description=(
+            "Filter by DTC status. 'stored' = confirmed faults, "
+            "'pending' = unconfirmed (not yet two-trip "
+            "validated)."
+        ),
+    )
+    ecu: Literal["engine", "abs", "all"] = Field(
+        default="all",
+        description=(
+            "Filter by originating ECU."
+        ),
+    )
+
+
+class LookupDTCInput(BaseModel):
+    """Input for the lookup_dtc tool.
+
+    Decodes one DTC to description + suspect subsystem + related
+    signals.  Falls back to manual-search guidance for codes
+    without a decoder.
+    """
+
+    code: str = Field(
+        ...,
+        min_length=2,
+        description=(
+            "DTC code. Standard format like 'P0117', or "
+            "Yamaha proprietary raw hex like "
+            "'87F11043000000000000CB'."
+        ),
+    )
+
+
+class DelegateToOBDAgentInput(BaseModel):
+    """Input for the delegate_to_obd_agent tool.
+
+    Hands an investigation inquiry off to the OBD sub-agent
+    (restricted to the 6 OBD primitives), receives back a
+    structured finding the main agent can quote.
+    """
+
+    inquiry: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description=(
+            "The investigation question to pose. Examples: "
+            "'Investigate stored DTCs and tell me what's normal "
+            "vs. abnormal.', 'What does the charging behaviour "
+            "look like across the trip?', 'Are there any "
+            "thermal anomalies in the coolant or cylinder head "
+            "temperature?'."
+        ),
+    )
+
+
+class DelegateToManualAgentInput(BaseModel):
+    """Input for the delegate_to_manual_agent tool.
+
+    Hands a manual-lookup inquiry to the manual sub-agent,
+    receives back a structured finding with cited sections.
+    """
+
+    inquiry: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description=(
+            "The lookup question to pose. Examples: "
+            "'What is the diagnostic procedure for DTC P0117 "
+            "on MWS-150-A?', 'What is the spark plug torque "
+            "specification?', 'How do I test the coolant "
+            "temperature sensor circuit?'."
+        ),
+    )
+    obd_context: Optional[str] = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "Optional OBD findings context to help the manual "
+            "agent disambiguate (e.g. observed DTCs, key signal "
+            "anomalies)."
         ),
     )

--- a/diagnostic_api/app/harness_tools/obd_loader.py
+++ b/diagnostic_api/app/harness_tools/obd_loader.py
@@ -1,0 +1,483 @@
+"""Yamaha-aware raw OBD data loader for the agent toolset.
+
+The existing ``obd_agent.log_parser.parse_log_file`` expects tab-separated
+internal TSV format produced by the format normalizer.  That path drops
+``A_YAM_*`` Yamaha-proprietary columns (see ``format_normalizer.py``
+APP-53 note), which would defeat HARNESS-19's locked decision to expose
+those signals to the agent.
+
+This loader bypasses the normalizer and reads the raw uploaded bytes
+directly, returning all columns (canonical K-Line ``A_KL_*`` plus
+proprietary ``A_YAM_*``) so the new investigation tools can answer
+questions about the full signal inventory.
+
+Two formats are supported transparently:
+
+1. **Yamaha dual-channel CSV** — comma-separated rows with a ``#``-prefixed
+   metadata block.  Detected by a ``# Yamaha Dual`` marker in the first
+   few lines.  Metadata block parsed for DTCs and channel info.
+2. **Standard OBD TSV** — tab-separated rows with the multi-line header
+   produced by python-OBD loggers.  Delegated to
+   ``obd_agent.log_parser.parse_log_file``.
+
+The unified return type is ``OBDLogData`` — rows + signal column names +
+DTC entries pulled from metadata + format tag.
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Tuple
+
+import structlog
+
+from app.config import settings
+from app.db.session import SessionLocal
+from app.models_db import OBDAnalysisSession
+from obd_agent.log_parser import parse_log_file
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Public types ─────────────────────────────────────────────────
+
+
+OBDLogFormat = Literal["yamaha_dual", "standard_tsv", "unknown"]
+"""Detected raw-file format tag."""
+
+
+@dataclass(frozen=True)
+class MetadataDTC:
+    """One DTC entry pulled from a Yamaha metadata header.
+
+    Attributes:
+        code: Raw code string (Yamaha hex format).
+        status: ``"stored"`` or ``"pending"``.
+        ecu: Originating ECU label (e.g. ``"K-Line"``).
+    """
+
+    code: str
+    status: Literal["stored", "pending"]
+    ecu: str
+
+
+@dataclass
+class OBDLogData:
+    """Parsed OBD log with full column preservation.
+
+    Attributes:
+        format: Detected format tag.
+        rows: List of column-name → raw-string-value row dicts.
+            Empty list if the file has no data rows.
+        columns: Ordered column names from the header (including
+            ``A_YAM_*`` proprietary columns for Yamaha format).
+            Excludes the ``Timestamp`` column.
+        metadata_dtcs: DTC entries pulled from the ``#`` metadata
+            block (Yamaha format).  Empty list for other formats.
+        metadata_lines: Raw ``#``-prefixed metadata lines (Yamaha
+            format), preserved verbatim for downstream tools that
+            want to surface them.
+        channels_present: ECU channels that have data in this log
+            (e.g. ``{"engine"}``).  ``"engine"`` is set when any
+            ``A_KL_*`` or ``A_YAM_*`` column is present.
+            ``"abs"`` is set when CAN ABS columns are present
+            (none in the current fixture).
+    """
+
+    format: OBDLogFormat
+    rows: List[Dict[str, str]] = field(default_factory=list)
+    columns: List[str] = field(default_factory=list)
+    metadata_dtcs: List[MetadataDTC] = field(default_factory=list)
+    metadata_lines: List[str] = field(default_factory=list)
+    channels_present: set = field(default_factory=set)
+
+
+# ── File-path resolution ─────────────────────────────────────────
+
+
+def resolve_log_path(session_id: str) -> Path:
+    """Resolve the raw OBD log file path from a session UUID.
+
+    Looks up ``raw_input_file_path`` on the ``OBDAnalysisSession``
+    row and joins it with ``settings.obd_log_storage_path``.  Mirrors
+    the pattern used by the legacy ``read_obd_data`` tool so test
+    fixtures and production storage paths line up identically.
+
+    Args:
+        session_id: UUID string identifying the session.
+
+    Returns:
+        Absolute filesystem path to the raw log.
+
+    Raises:
+        ValueError: If the session_id is malformed, the row doesn't
+            exist, or the row has no recorded raw file path.
+    """
+    try:
+        sid = uuid.UUID(session_id)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(
+            f"Invalid session_id format: {session_id}"
+        ) from exc
+
+    db = SessionLocal()
+    try:
+        session = (
+            db.query(OBDAnalysisSession)
+            .filter(OBDAnalysisSession.id == sid)
+            .first()
+        )
+        if session is None:
+            raise ValueError(
+                f"Session not found: {session_id}"
+            )
+        raw_path = session.raw_input_file_path
+        if not raw_path:
+            raise ValueError(
+                f"Session {session_id} has no raw OBD log "
+                f"file on disk."
+            )
+        return Path(settings.obd_log_storage_path) / raw_path
+    finally:
+        db.close()
+
+
+# ── Format detection ─────────────────────────────────────────────
+
+
+_YAMAHA_DUAL_MARKERS = (
+    "yamaha dual",
+    "ch.a:",
+    "kl_ecu_name",
+)
+
+
+def detect_format(text: str) -> OBDLogFormat:
+    """Classify raw log content by format.
+
+    Reads the first ~60 lines and looks for distinguishing markers.
+    Doesn't open the file from a path so callers can detect from
+    in-memory content during tests.
+
+    Args:
+        text: Raw file content as a string.
+
+    Returns:
+        Format tag.  ``"unknown"`` if no marker fires.
+    """
+    head = "\n".join(text.splitlines()[:60]).lower()
+    if any(marker in head for marker in _YAMAHA_DUAL_MARKERS):
+        return "yamaha_dual"
+    # Standard OBD TSV uses "OBD Data Log" header (see log_parser).
+    if "obd data log" in head and "\t" in head:
+        return "standard_tsv"
+    # Tab-separated with Timestamp header — assume standard TSV.
+    for line in text.splitlines()[:30]:
+        if line.startswith("Timestamp\t"):
+            return "standard_tsv"
+    return "unknown"
+
+
+# ── Yamaha-dual parsing ──────────────────────────────────────────
+
+
+_DTC_METADATA_RE = re.compile(
+    r"^#\s*(?P<channel>[A-Za-z]+)_(?P<status>Stored|Pending)\s*:\s*"
+    r"(?P<code>[0-9A-Fa-fxX]{4,})\s*$",
+)
+_CHANNEL_LABEL = {
+    "kl": "K-Line",
+    "can": "CAN",
+}
+
+
+def _parse_yamaha_metadata_dtcs(
+    metadata_lines: List[str],
+) -> List[MetadataDTC]:
+    """Extract DTC entries from a Yamaha-format metadata block.
+
+    The fixture format puts DTCs in lines like::
+
+        # DTCs:
+        #   KL_Stored: 87F11043000000000000CB
+        #   KL_Pending: 87F11047000000000000CF
+
+    Args:
+        metadata_lines: Raw ``#``-prefixed lines from the header.
+
+    Returns:
+        Ordered list of parsed DTCs (stored first, pending second,
+        in file order).
+    """
+    out: List[MetadataDTC] = []
+    for raw in metadata_lines:
+        match = _DTC_METADATA_RE.match(raw.strip())
+        if not match:
+            continue
+        channel = match.group("channel").lower()
+        ecu_label = _CHANNEL_LABEL.get(channel, channel.upper())
+        status = match.group("status").lower()  # "stored" or "pending"
+        code = match.group("code").upper()
+        out.append(MetadataDTC(
+            code=code,
+            status=status,  # type: ignore[arg-type]
+            ecu=ecu_label,
+        ))
+    return out
+
+
+def _parse_yamaha_dual_csv(text: str) -> OBDLogData:
+    """Parse a Yamaha dual-channel CSV file into ``OBDLogData``.
+
+    Splits metadata (``#``-prefixed lines) from data, reads CSV with
+    the stdlib reader (handles quoted fields, embedded commas, etc.),
+    and preserves all columns including ``A_YAM_*`` proprietary
+    fields.
+
+    Args:
+        text: Full file content.
+
+    Returns:
+        Parsed ``OBDLogData`` with format=``"yamaha_dual"``.
+
+    Raises:
+        ValueError: If no header row is present.
+    """
+    metadata_lines: List[str] = []
+    data_lines: List[str] = []
+    for raw in text.splitlines():
+        if raw.startswith("#"):
+            metadata_lines.append(raw)
+            continue
+        # Drop the unicode "═" separator line if present.
+        if raw and raw[0] not in (",", "\t") and "═" in raw:
+            continue
+        if not raw:
+            continue
+        data_lines.append(raw)
+
+    if not data_lines:
+        raise ValueError(
+            "Yamaha dual-channel CSV has no data rows."
+        )
+
+    reader = csv.reader(io.StringIO("\n".join(data_lines)))
+    rows_iter = iter(reader)
+    try:
+        raw_headers = next(rows_iter)
+    except StopIteration as exc:
+        raise ValueError(
+            "Yamaha dual-channel CSV missing header row."
+        ) from exc
+
+    headers = [h.strip() for h in raw_headers]
+    if "Timestamp" not in headers:
+        raise ValueError(
+            "Yamaha dual-channel CSV header is missing the "
+            "Timestamp column."
+        )
+
+    rows: List[Dict[str, str]] = []
+    for raw_row in rows_iter:
+        if not raw_row or all(c.strip() == "" for c in raw_row):
+            continue
+        row: Dict[str, str] = {}
+        for i, h in enumerate(headers):
+            val = raw_row[i].strip() if i < len(raw_row) else ""
+            row[h] = val
+        rows.append(row)
+
+    metadata_dtcs = _parse_yamaha_metadata_dtcs(metadata_lines)
+
+    channels: set = set()
+    if any(h.startswith(("A_KL_", "A_YAM_")) for h in headers):
+        channels.add("engine")
+    if any(h.startswith("B_") for h in headers):
+        channels.add("abs")
+
+    # Strip Timestamp from columns inventory — it is implicit and
+    # tools list signal columns only.
+    signal_cols = [h for h in headers if h != "Timestamp"]
+
+    return OBDLogData(
+        format="yamaha_dual",
+        rows=rows,
+        columns=signal_cols,
+        metadata_dtcs=metadata_dtcs,
+        metadata_lines=metadata_lines,
+        channels_present=channels,
+    )
+
+
+# ── Standard TSV adapter ─────────────────────────────────────────
+
+
+def _parse_standard_tsv(path: Path, text: str) -> OBDLogData:
+    """Parse a standard OBD TSV via the existing log_parser path.
+
+    Delegates row parsing to ``parse_log_file()`` then derives the
+    column inventory from the first row's keys.  No metadata DTCs
+    (standard format puts DTCs inside ``GET_DTC`` / ``GET_CURRENT_DTC``
+    columns, surfaced separately by ``obd_dtcs.list_dtcs``).
+
+    Args:
+        path: File path (passed through to ``parse_log_file``).
+        text: File content (used only for channel detection).
+
+    Returns:
+        Parsed ``OBDLogData`` with format=``"standard_tsv"``.
+    """
+    rows = parse_log_file(path)
+    columns: List[str] = []
+    if rows:
+        columns = [c for c in rows[0].keys() if c != "Timestamp"]
+    channels: set = set()
+    if rows:
+        channels.add("engine")
+    return OBDLogData(
+        format="standard_tsv",
+        rows=rows,
+        columns=columns,
+        metadata_dtcs=[],
+        metadata_lines=[],
+        channels_present=channels,
+    )
+
+
+# ── Public entry point ───────────────────────────────────────────
+
+
+def load_obd_data(path: Path) -> OBDLogData:
+    """Load raw OBD data from disk, preserving all columns.
+
+    Detects the file format and dispatches to the appropriate
+    parser.  Always returns the full column inventory so the agent
+    toolset can expose ``A_YAM_*`` proprietary signals (HARNESS-19
+    locked decision).
+
+    Args:
+        path: Absolute path to the raw log file.
+
+    Returns:
+        ``OBDLogData`` with rows, columns, and (for Yamaha format)
+        metadata DTCs.
+
+    Raises:
+        FileNotFoundError: If ``path`` doesn't exist.
+        ValueError: If the file format cannot be parsed.
+    """
+    if not path.exists():
+        raise FileNotFoundError(
+            f"OBD log file not found: {path}"
+        )
+    text = path.read_text(encoding="utf-8", errors="replace")
+    # Defensive BOM strip — the Yamaha fixture is UTF-8 with BOM
+    # and ``read_text(encoding="utf-8")`` does not consume it.
+    # Without this the first metadata line leaks into the CSV
+    # body and the header parser fails.
+    if text.startswith("﻿"):
+        text = text[1:]
+    fmt = detect_format(text)
+    if fmt == "yamaha_dual":
+        return _parse_yamaha_dual_csv(text)
+    if fmt == "standard_tsv":
+        return _parse_standard_tsv(path, text)
+    # Unknown format: try standard TSV (most-common upload shape)
+    # and if it fails, fall back to Yamaha CSV.  This ordering keeps
+    # the happy path fast for standard logs.
+    try:
+        return _parse_standard_tsv(path, text)
+    except Exception:  # noqa: BLE001
+        return _parse_yamaha_dual_csv(text)
+
+
+def load_for_session(session_id: str) -> OBDLogData:
+    """Resolve a session's raw file path and load it.
+
+    Convenience wrapper combining ``resolve_log_path`` and
+    ``load_obd_data`` for tools that operate on a session UUID.
+
+    Args:
+        session_id: OBD analysis session UUID string.
+
+    Returns:
+        Parsed ``OBDLogData``.
+
+    Raises:
+        ValueError: From ``resolve_log_path`` on missing session.
+        FileNotFoundError: If the file path resolves but the file
+            is missing on disk.
+    """
+    path = resolve_log_path(session_id)
+    return load_obd_data(path)
+
+
+# ── Time helpers shared across OBD tools ─────────────────────────
+
+
+_TIMESTAMP_FORMATS = (
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def parse_timestamp(raw: str):
+    """Parse an OBD timestamp string to a naive datetime.
+
+    Tolerates the fixture's millisecond-suffix format
+    (``2026-05-08 11:20:40.508``) and the standard-TSV
+    second-precision format.  Returns ``None`` on failure so
+    callers can skip bad rows without raising.
+
+    Args:
+        raw: Timestamp string from a row dict.
+
+    Returns:
+        Parsed ``datetime`` or ``None``.
+    """
+    from datetime import datetime
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    for fmt in _TIMESTAMP_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    # Last attempt: ISO 8601 parser.
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def try_float(raw: str) -> Optional[float]:
+    """Parse a numeric cell, returning None on N/A or failure.
+
+    Treats common missing-value tokens (``"N/A"``, empty string,
+    ``"nan"``) as missing without surfacing an error.
+
+    Args:
+        raw: Raw cell string.
+
+    Returns:
+        Parsed float or ``None``.
+    """
+    if raw is None:
+        return None
+    s = raw.strip()
+    if not s or s.upper() == "N/A" or s.lower() == "nan":
+        return None
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None

--- a/diagnostic_api/app/harness_tools/obd_signal_inventory.py
+++ b/diagnostic_api/app/harness_tools/obd_signal_inventory.py
@@ -1,0 +1,335 @@
+"""Signal inventory + classification for the OBD investigation tools.
+
+Builds a typed view of the columns present in a parsed ``OBDLogData``
+so the agent tools (``list_signals``, ``read_window``,
+``get_signal_stats``, ``find_events``) can reason about which signals
+are dense vs sparse, which ECU they came from, and what units they
+carry.
+
+Units for ``A_KL_*`` and ``A_YAM_*`` columns come from a hand-curated
+map below (HARNESS-19 locked decision: expose Yamaha proprietary
+columns under their original names, with best-effort unit annotations
+where we know them).
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Dict, List, Literal, Optional
+
+from app.harness_tools.obd_loader import OBDLogData, try_float
+
+
+Subsystem = Literal["engine", "abs", "other"]
+"""Subsystem tag for a single signal."""
+
+
+# ── Curated unit map ─────────────────────────────────────────────
+
+
+_YAMAHA_UNITS: Dict[str, str] = {
+    # K-Line canonical PIDs (Channel A, engine ECU)
+    "A_KL_RPM": "rpm",
+    "A_KL_SPEED": "km/h",
+    "A_KL_COOLANT_TEMP": "°C",
+    "A_KL_IAT": "°C",
+    "A_KL_MAP": "kPa",
+    "A_KL_BARO": "kPa",
+    "A_KL_TIMING_ADV": "deg",
+    "A_KL_TPS": "%",
+    "A_KL_REL_TPS": "%",
+    "A_KL_ENGINE_LOAD": "%",
+    "A_KL_CTRL_VOLT": "V",
+    # Yamaha proprietary confirmed
+    "A_YAM_BARO_REF": "kPa",
+    "A_YAM_BATT_V": "V",
+    "A_YAM_CHT": "°C",
+    "A_YAM_ECT": "°C",
+    "A_YAM_IAT": "°C",
+    "A_YAM_IGN": "deg",
+    "A_YAM_INJ_MS": "ms",
+    "A_YAM_INJ_US": "us",
+    "A_YAM_ISC": "step",
+    "A_YAM_RPM": "rpm",
+    "A_YAM_VVA": "deg",
+    # Yamaha proprietary provisional (raw bytes — unit unknown)
+    "A_YAM_BATT_RAW": "raw",
+    "A_YAM_MAP_RAW": "raw",
+    "A_YAM_O2_FB_RAW": "raw",
+    "A_YAM_TPS_RAW": "raw",
+}
+"""Curated unit annotations for Yamaha-format columns.
+
+For standard-OBD-TSV columns we fall back to the unit map in
+``obd_agent.log_parser._PID_UNITS``.
+"""
+
+
+def _standard_unit(col: str) -> Optional[str]:
+    """Look up the unit for a standard OBD-II PID column.
+
+    Imports lazily to avoid a top-level circular dependency with
+    ``obd_agent``.
+    """
+    from obd_agent.log_parser import _PID_UNITS
+    return _PID_UNITS.get(col)
+
+
+# ── Signal descriptor ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SignalDescriptor:
+    """Typed view of one column in an OBD log.
+
+    Attributes:
+        name: Column name as it appears in the file (e.g. ``RPM``
+            or ``A_YAM_INJ_MS``).
+        units: Engineering units string when known, else
+            ``"unknown"``.  ``"raw"`` for Yamaha provisional bytes.
+        subsystem: ECU subsystem tag.
+        density: Fraction of rows with a parseable numeric value.
+            ``0.0`` means the column is all N/A.
+        valid_count: Absolute count of parseable numeric samples.
+        total_count: Total row count.
+    """
+
+    name: str
+    units: str
+    subsystem: Subsystem
+    density: float
+    valid_count: int
+    total_count: int
+
+    @property
+    def density_label(self) -> str:
+        """Coarse density label for human-friendly output."""
+        if self.density >= 0.99:
+            return "dense"
+        if self.density >= 0.5:
+            return f"sparse ({int(self.density * 100)}%)"
+        if self.density > 0:
+            return f"very sparse ({int(self.density * 100)}%)"
+        return "all N/A"
+
+
+# ── Classification + inventory build ─────────────────────────────
+
+
+_STANDARD_PID_NAMES = frozenset({
+    "RPM", "SPEED", "COOLANT_TEMP", "INTAKE_TEMP", "IAT",
+    "MAP", "BARO", "BAROMETRIC_PRESSURE",
+    "ENGINE_LOAD", "ABSOLUTE_LOAD",
+    "THROTTLE_POS", "THROTTLE_POS_B", "RELATIVE_THROTTLE_POS",
+    "TIMING_ADVANCE", "MAF", "FUEL_RAIL_PRESSURE_DIRECT",
+    "SHORT_FUEL_TRIM_1", "LONG_FUEL_TRIM_1",
+    "O2_B1S2", "O2_S1_WR_CURRENT",
+    "CONTROL_MODULE_VOLTAGE", "ELM_VOLTAGE",
+    "ACCELERATOR_POS_D", "ACCELERATOR_POS_E",
+    "RUN_TIME", "DISTANCE_W_MIL", "DISTANCE_SINCE_DTC_CLEAR",
+    "COMMANDED_EQUIV_RATIO",
+})
+"""Known standard OBD-II PID column names (no prefix).
+
+Used by ``classify_subsystem`` to recognise pre-normalised
+columns (RPM, COOLANT_TEMP, etc.) as engine signals.
+"""
+
+
+def classify_subsystem(col: str) -> Subsystem:
+    """Tag a column with its originating ECU subsystem.
+
+    Heuristic based on the Yamaha-dual prefix convention
+    (``A_*`` = Channel A engine, ``B_*`` = Channel B ABS) plus
+    a curated list of standard OBD-II PID names that have no
+    prefix and represent engine signals.
+
+    Args:
+        col: Column name.
+
+    Returns:
+        Subsystem tag.
+    """
+    if col.startswith("A_KL_") or col.startswith("A_YAM_"):
+        return "engine"
+    if col.startswith("B_"):
+        return "abs"
+    if col.upper() in _STANDARD_PID_NAMES:
+        return "engine"
+    return "other"
+
+
+def units_for(col: str) -> str:
+    """Resolve the engineering unit for a column.
+
+    Order of lookup:
+    1. Yamaha-format curated map.
+    2. Standard OBD-II ``_PID_UNITS`` map (via lazy import).
+    3. Fallback ``"unknown"``.
+    """
+    if col in _YAMAHA_UNITS:
+        return _YAMAHA_UNITS[col]
+    std = _standard_unit(col)
+    if std is not None:
+        return std
+    return "unknown"
+
+
+def _density(rows: List[Dict[str, str]], col: str) -> tuple:
+    """Compute (valid_count, total_count) for a column.
+
+    ``valid_count`` counts cells parseable as float (per
+    ``try_float`` — treats ``N/A`` as missing).
+    """
+    total = len(rows)
+    if total == 0:
+        return 0, 0
+    valid = sum(
+        1 for r in rows if try_float(r.get(col, "")) is not None
+    )
+    return valid, total
+
+
+def build_inventory(
+    data: OBDLogData,
+) -> List[SignalDescriptor]:
+    """Build a ``SignalDescriptor`` list for every signal column.
+
+    ``Timestamp`` and any all-zero-length string columns are
+    excluded.  Density is computed by scanning the rows once per
+    column — O(rows * cols) but the fixture is small.
+
+    Args:
+        data: Parsed log.
+
+    Returns:
+        Ordered list of descriptors matching ``data.columns``.
+    """
+    out: List[SignalDescriptor] = []
+    for col in data.columns:
+        valid, total = _density(data.rows, col)
+        density = (valid / total) if total else 0.0
+        out.append(SignalDescriptor(
+            name=col,
+            units=units_for(col),
+            subsystem=classify_subsystem(col),
+            density=density,
+            valid_count=valid,
+            total_count=total,
+        ))
+    return out
+
+
+# ── Lookup helpers used by the signal tools ──────────────────────
+
+
+def filter_inventory(
+    inventory: List[SignalDescriptor],
+    pattern: Optional[str],
+    subsystem: Literal["engine", "abs", "all"],
+) -> List[SignalDescriptor]:
+    """Filter an inventory by glob pattern and subsystem.
+
+    Pattern matching is case-insensitive against the column name.
+    Use shell-style globs (``*TEMP*``, ``A_YAM_*``, ``RPM``).
+
+    Args:
+        inventory: Full inventory from ``build_inventory``.
+        pattern: Optional glob pattern.
+        subsystem: Subsystem filter (``"all"`` = no filter).
+
+    Returns:
+        Filtered list.
+    """
+    out = list(inventory)
+    if subsystem != "all":
+        out = [d for d in out if d.subsystem == subsystem]
+    if pattern:
+        pat = pattern.lower()
+        out = [
+            d for d in out
+            if fnmatch.fnmatchcase(d.name.lower(), pat)
+        ]
+    return out
+
+
+def resolve_signal_name(
+    name: str,
+    inventory: List[SignalDescriptor],
+) -> Optional[str]:
+    """Resolve a user-supplied signal name to a canonical column.
+
+    Matching strategy:
+    1. Exact match against an inventory column name.
+    2. Case-insensitive match.
+    3. Suffix match — useful when the LLM passes ``RPM`` and the
+       column is ``A_YAM_RPM``.  Returns the shortest matching
+       column name to bias toward canonical ``A_KL_`` columns over
+       proprietary ``A_YAM_`` ones.
+
+    Args:
+        name: Caller-supplied signal name.
+        inventory: Full inventory.
+
+    Returns:
+        Canonical column name or ``None`` if no match.
+    """
+    if not name:
+        return None
+    names = [d.name for d in inventory]
+    if name in names:
+        return name
+    upper = name.upper()
+    for col in names:
+        if col.upper() == upper:
+            return col
+    # Suffix match — prefer shortest (canonical K-Line over Yamaha
+    # proprietary when both are present).
+    candidates = [c for c in names if c.upper().endswith(upper)]
+    if candidates:
+        return min(candidates, key=len)
+    return None
+
+
+def fuzzy_suggestions(
+    name: str,
+    inventory: List[SignalDescriptor],
+    max_suggestions: int = 3,
+) -> List[str]:
+    """Suggest close-match signal names for an unknown input.
+
+    Cheap substring + edit-distance hybrid — returns names that
+    share a common substring with the input, ranked by length
+    proximity to the query.  Falls back to first-N inventory
+    columns if nothing matches.
+
+    Args:
+        name: Unknown signal name from the caller.
+        inventory: Full inventory.
+        max_suggestions: Maximum suggestions to return.
+
+    Returns:
+        Up to ``max_suggestions`` candidate column names.
+    """
+    if not inventory:
+        return []
+    query = (name or "").lower()
+    scored: List[tuple] = []
+    for d in inventory:
+        col_lower = d.name.lower()
+        # Substring hit gets best score.
+        if query and query in col_lower:
+            scored.append((0, d.name))
+            continue
+        # Otherwise score by shared characters.
+        shared = len(set(col_lower) & set(query))
+        if shared:
+            scored.append((10 - shared, d.name))
+    scored.sort(key=lambda t: (t[0], len(t[1])))
+    suggestions = [name for _, name in scored[:max_suggestions]]
+    if suggestions:
+        return suggestions
+    return [d.name for d in inventory[:max_suggestions]]

--- a/diagnostic_api/tests/harness_tools/__init__.py
+++ b/diagnostic_api/tests/harness_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for harness tools."""

--- a/diagnostic_api/tests/harness_tools/test_obd_loader.py
+++ b/diagnostic_api/tests/harness_tools/test_obd_loader.py
@@ -1,0 +1,269 @@
+"""Unit tests for the Yamaha-aware OBD log loader.
+
+Exercises ``detect_format``, the Yamaha-dual CSV parser, and the
+metadata-DTC extractor against the real road-test fixture.
+
+The fixture lives at ``obd_agent/fixtures/yamaha_dual_road_test_20260508.csv``
+— a 257-sample real recording committed in #80 (PR #82).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.harness_tools.obd_loader import (
+    OBDLogData,
+    _parse_yamaha_metadata_dtcs,
+    detect_format,
+    load_obd_data,
+    parse_timestamp,
+    try_float,
+)
+
+# Path to the real Yamaha road-test fixture.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_YAMAHA_FIXTURE = (
+    _REPO_ROOT
+    / "obd_agent"
+    / "fixtures"
+    / "yamaha_dual_road_test_20260508.csv"
+)
+
+
+@pytest.fixture(scope="module")
+def yamaha_data() -> OBDLogData:
+    """Parse the Yamaha fixture once for the module."""
+    assert _YAMAHA_FIXTURE.exists(), (
+        f"Yamaha fixture missing: {_YAMAHA_FIXTURE}"
+    )
+    return load_obd_data(_YAMAHA_FIXTURE)
+
+
+# ── Format detection ─────────────────────────────────────────────
+
+
+class TestDetectFormat:
+    """Tests for ``detect_format``."""
+
+    def test_detects_yamaha_dual_from_marker_comment(self) -> None:
+        """The 'Yamaha Dual' marker in the header is recognized."""
+        sample = "\n".join([
+            "# Yamaha Dual OBDLink EX Log",
+            "# vehicle_id: TEST",
+            "Timestamp,A_KL_RPM",
+            "2026-05-08 11:00:00.000,1500.0",
+        ])
+        assert detect_format(sample) == "yamaha_dual"
+
+    def test_detects_yamaha_from_a_kl_columns(self) -> None:
+        """A_KL_ / A_YAM_ column prefixes trigger Yamaha detection
+        even without the comment marker (defense-in-depth)."""
+        sample = "\n".join([
+            "# Ch.A: K-Line",
+            "Timestamp,A_KL_RPM",
+            "t,1500",
+        ])
+        assert detect_format(sample) == "yamaha_dual"
+
+    def test_detects_standard_tsv(self) -> None:
+        """Standard python-OBD TSV format is recognised."""
+        sample = "\n".join([
+            "OBD Data Log",
+            "Start Time: 2025-01-01 00:00:00",
+            "--------",
+            "Timestamp\tRPM\tSPEED",
+            "--------",
+            "2025-01-01 00:00:00\t1500\t30",
+        ])
+        assert detect_format(sample) == "standard_tsv"
+
+    def test_unknown_format_returns_unknown(self) -> None:
+        """Non-OBD content gets the unknown tag."""
+        assert detect_format("hello world") == "unknown"
+
+    def test_detects_real_yamaha_fixture(self) -> None:
+        """The committed fixture file is classified as yamaha_dual."""
+        text = _YAMAHA_FIXTURE.read_text(encoding="utf-8")
+        assert detect_format(text) == "yamaha_dual"
+
+
+# ── Yamaha metadata DTC extractor ────────────────────────────────
+
+
+class TestYamahaMetadataDTCs:
+    """Tests for ``_parse_yamaha_metadata_dtcs``."""
+
+    def test_extracts_stored_and_pending(self) -> None:
+        """Stored and pending DTC lines are parsed with status tags."""
+        lines = [
+            "# DTCs:",
+            "#   KL_Stored: 87F11043000000000000CB",
+            "#   KL_Pending: 87F11047000000000000CF",
+        ]
+        out = _parse_yamaha_metadata_dtcs(lines)
+        assert len(out) == 2
+        statuses = {d.status for d in out}
+        assert statuses == {"stored", "pending"}
+        codes = [d.code for d in out]
+        assert "87F11043000000000000CB" in codes
+        assert "87F11047000000000000CF" in codes
+
+    def test_attaches_ecu_label(self) -> None:
+        """KL_ prefix maps to 'K-Line' ECU label."""
+        out = _parse_yamaha_metadata_dtcs([
+            "#   KL_Stored: ABCDEF0123",
+        ])
+        assert out[0].ecu == "K-Line"
+
+    def test_skips_unrelated_metadata_lines(self) -> None:
+        """Non-DTC metadata lines are ignored without erroring."""
+        out = _parse_yamaha_metadata_dtcs([
+            "# vehicle_id: TEST",
+            "# Start: 2026-05-08 11:00:00",
+        ])
+        assert out == []
+
+
+# ── End-to-end: parse the real fixture ───────────────────────────
+
+
+class TestRealYamahaFixture:
+    """Tests against the committed Yamaha road-test fixture.
+
+    Validates the HARNESS-19 locked decision: ``A_YAM_*`` proprietary
+    columns are exposed under their original names, and the metadata
+    block's Yamaha hex DTCs are surfaced.
+    """
+
+    def test_format_classified_as_yamaha_dual(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        assert yamaha_data.format == "yamaha_dual"
+
+    def test_rows_loaded(self, yamaha_data: OBDLogData) -> None:
+        """The fixture has roughly 257 data rows."""
+        # Fixture committed shape: 257 samples per #80 PR description.
+        # Allow a small tolerance in case the committed file is
+        # tweaked later (no semantic regression as long as it's
+        # well over 100 samples).
+        assert len(yamaha_data.rows) > 200
+
+    def test_a_yam_columns_preserved(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """A_YAM_* proprietary columns survive the loader.
+
+        This is the HARNESS-19 locked decision — the legacy
+        format_normalizer.py drops these, the new loader must NOT.
+        """
+        yamaha_cols = [
+            c for c in yamaha_data.columns
+            if c.startswith("A_YAM_")
+        ]
+        # Fixture has 16 A_YAM_* columns per the header (see CSV
+        # rows 9-10).
+        assert len(yamaha_cols) >= 10, (
+            f"Expected A_YAM_* columns to be preserved, got "
+            f"{yamaha_cols}"
+        )
+
+    def test_a_kl_columns_preserved(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """K-Line canonical PIDs are present."""
+        for col in (
+            "A_KL_RPM",
+            "A_KL_SPEED",
+            "A_KL_COOLANT_TEMP",
+            "A_KL_MAP",
+        ):
+            assert col in yamaha_data.columns, (
+                f"Missing K-Line column {col}"
+            )
+
+    def test_metadata_dtcs_extracted(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Fixture's 2 Yamaha-hex DTCs are surfaced via metadata."""
+        assert len(yamaha_data.metadata_dtcs) == 2
+        codes = [d.code for d in yamaha_data.metadata_dtcs]
+        assert "87F11043000000000000CB" in codes
+        assert "87F11047000000000000CF" in codes
+        statuses = sorted(d.status for d in yamaha_data.metadata_dtcs)
+        assert statuses == ["pending", "stored"]
+
+    def test_engine_channel_present(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Engine ECU (K-Line) channel detected from A_* columns."""
+        assert "engine" in yamaha_data.channels_present
+
+    def test_first_row_is_warmup_na(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """First data row contains N/A — sensor warm-up."""
+        first = yamaha_data.rows[0]
+        # Fixture row 17 (first data row) is all N/A.
+        rpm_val = first.get("A_KL_RPM", "")
+        assert rpm_val.strip().upper() == "N/A"
+
+    def test_subsequent_rows_have_numeric_values(
+        self, yamaha_data: OBDLogData,
+    ) -> None:
+        """Rows after warm-up contain parseable floats."""
+        # Row index 1 should have numeric RPM (e.g. 0.0 idle).
+        second = yamaha_data.rows[1]
+        assert try_float(second["A_KL_RPM"]) is not None
+
+
+# ── Time helpers ─────────────────────────────────────────────────
+
+
+class TestTimestampParser:
+    """Tests for ``parse_timestamp``."""
+
+    def test_parses_millisecond_format(self) -> None:
+        """Fixture format with .508 ms suffix parses."""
+        dt = parse_timestamp("2026-05-08 11:20:40.508")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.second == 40
+
+    def test_parses_second_precision(self) -> None:
+        dt = parse_timestamp("2026-05-08 11:20:40")
+        assert dt is not None
+
+    def test_parses_iso_t_separator(self) -> None:
+        dt = parse_timestamp("2026-05-08T11:20:40")
+        assert dt is not None
+
+    def test_returns_none_for_garbage(self) -> None:
+        assert parse_timestamp("not a date") is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert parse_timestamp("") is None
+
+
+class TestTryFloat:
+    """Tests for ``try_float`` missing-value handling."""
+
+    def test_n_a_token_returns_none(self) -> None:
+        assert try_float("N/A") is None
+
+    def test_n_a_lowercase_returns_none(self) -> None:
+        assert try_float("n/a") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert try_float("") is None
+        assert try_float("   ") is None
+
+    def test_nan_returns_none(self) -> None:
+        assert try_float("nan") is None
+
+    def test_numeric_string_returns_float(self) -> None:
+        assert try_float("3.14") == pytest.approx(3.14)
+
+    def test_integer_string_returns_float(self) -> None:
+        assert try_float("42") == 42.0

--- a/docs/plans/2026-05-16-obd-toolset-design.md
+++ b/docs/plans/2026-05-16-obd-toolset-design.md
@@ -1,0 +1,593 @@
+# Design: Agent-Native OBD Investigation Toolset (HARNESS-19)
+
+**Date**: 2026-05-16
+**Status**: Approved
+**Author**: Xiangzhu Yan
+**Ticket**: [HARNESS-19 (#85)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/85)
+**Doc track**: V2 (harness / agent loop)
+
+## Context
+
+The V2 harness has the manual toolset working (`list_manuals`, `get_manual_toc`,
+`read_manual_section`, `search_manual`) and the eval framework is maturing in
+parallel (#74). On the OBD side only one tool exists — `read_obd_data`
+(overview + signal-query modes) — produced by the #69 toolset redesign.
+
+As of 2026-05-09 we also have **one real Yamaha road-test recording** committed
+as a regression fixture: `obd_agent/fixtures/yamaha_dual_road_test_20260508.csv`
+— 4 min 17 s, 257 samples at 1 Hz, dual-channel (K-Line engine ECU +
+CAN ABS ECU), healthy bike, 27 columns including 11 K-Line canonical PIDs and
+16 Yamaha-proprietary `A_YAM_*` fields, plus 2 stored Yamaha-hex DTCs.
+
+With real signal data in hand, it is time to design and scaffold the rest of
+the OBD-side toolset — clean-slate, not a port of the V1 deterministic
+pipeline.
+
+## Problem
+
+`read_obd_data` covers only the discovery + raw-window-read pair of cognitive
+primitives. An agent investigating real OBD data also needs:
+
+1. **Aggregation primitives** — without them, the agent burns tokens pulling
+   raw rows and doing arithmetic LLMs are unreliable at.
+2. **Event-finding primitives** — Grep-style "when does this signal meet this
+   condition?" — collapses 257 raw samples into a handful of useful windows.
+3. **DTC-specific tools** — the fixture has 2 stored DTCs in Yamaha hex format
+   (`87F11043…`), but no list/lookup/decode tools exist. Today the agent sees
+   raw hex strings with no path forward.
+4. **A_YAM_\* proprietary signals exposure** — `format_normalizer.py` strips
+   all `A_YAM_*` fields, losing ~60% of the Yamaha fixture's signal richness
+   (battery voltage, injection pulse, cylinder head temp, etc.).
+5. **A specialist sub-agent** — the manual side has `manual_agent.py` doing
+   focused work for the eval suite; the OBD side has nothing analogous, so the
+   main agent must do all OBD investigation in its own context.
+
+The toolset must be **agent-native**: tools provide *data*, not pre-digested
+conclusions. The V1 pipeline's `generate_clues` /`detect_anomalies` /
+`statistics_extractor` chain runs before the LLM in V1; for V2 the agent
+drives the investigation itself.
+
+## Requirements
+
+1. Six OBD investigation primitives mapped to distinct cognitive steps
+   (discover, read, aggregate, find-events, list-DTCs, lookup-DTC).
+2. A new OBD sub-agent (`run_obd_agent`) mirroring the established
+   `manual_agent.py` template — restricted toolset, structured-output
+   contract, no SSE / event-log persistence.
+3. Two delegation wrappers (`delegate_to_obd_agent`,
+   `delegate_to_manual_agent`) so the main agent can route compound
+   inquiries to specialists (hybrid Pattern 2, see §Approach).
+4. Tools must expose `A_YAM_*` proprietary signals under their original
+   column names.
+5. DTC tools must handle Yamaha-proprietary hex codes honestly: no
+   fabricated decodings; manual-search pivot for unknown formats.
+6. All tools return text (no multimodal — OBD data is tabular).
+7. Hermetic unit tests against the real Yamaha fixture; no network or LLM
+   calls. Smoke-tested sub-agent loop with mocked `LLMClient`.
+
+## Out of scope
+
+The following are deliberately deferred to follow-up tickets:
+
+- **Diagnostic accuracy benchmarks** — no labelled fault data exists yet.
+- **OBD golden set + eval harness** (parallel to #73 for manuals) — needs a
+  separate HARNESS-XX ticket once goldens can be generated.
+- **Cross-signal correlation tool** (`correlate_signals`) — agent can
+  approximate by reading two windows and reasoning; add only if evals show
+  it is needed.
+- **Anomaly-detection-as-a-tool** — would re-introduce the "pre-digested
+  analysis" pattern that #69 walked away from. May revisit later as a
+  derived-feature primitive (changepoint timestamps as *data*, not
+  conclusions).
+- **Annotation scratchpad** — useful for long sessions but introduces state
+  (where it lives, when it clears).
+- **Freeze-frame snapshot tool** — current fixture has no freeze-frame data.
+  Defer until a fixture exists.
+- **Real-time / streaming OBD ingestion**.
+- **Multi-vehicle generalisation** — Yamaha-first; Honda / others later.
+- **Yamaha-hex DTC decoder** — no public spec; reverse-engineering is its
+  own workstream.
+
+## Approach
+
+### Architectural pattern: hybrid (Pattern 2)
+
+Three patterns were considered:
+
+| Pattern | Main agent toolbox | Sub-agents in production? |
+|---|---|---|
+| 1 — Flat | All primitives directly | No (eval-only) |
+| **2 — Hybrid (chosen)** | **Primitives + delegation wrappers** | **Yes, via `delegate_to_*`** |
+| 3 — Pure delegation | Only delegation wrappers | Yes (primitives hidden from main) |
+
+Pattern 2 matches Claude Code's own design (it has `Read` / `Grep` / `Glob`
+*and* the `Task` sub-agent tool). The main agent does small things directly
+("what's the RPM range?") and delegates compound investigations
+("investigate the stored DTCs end-to-end").
+
+Pattern 3 is cleaner architecturally but rewrites the main agent's prompt in
+the same PR — too much risk in one change. Pattern 1 leaves sub-agents
+aspirational. Pattern 2 lands meaningful delegation without forcing a
+whole-architecture rewrite.
+
+### Tool decomposition philosophy
+
+Per Anthropic's *Writing tools for agents* guide and the manual-toolset
+precedent: each tool maps to one cognitive step. We split `read_obd_data`'s
+current two-mode shape (overview vs. signal-query) into separate tools
+(`list_signals` + `read_window`) so the agent never juggles modes within a
+single call.
+
+Tool-name analogs from Claude Code's own primitives:
+
+| Claude Code | OBD analog | Why |
+|---|---|---|
+| `Glob` | `list_signals(pattern, subsystem)` | discovery — what exists |
+| `Read` | `read_window(signals, t1, t2)` | targeted sample read |
+| `Grep` | `find_events(signal, predicate)` | where does condition hold |
+| (aggregate) | `get_signal_stats(signals, range)` | summary without raw rows |
+| (lookup) | `list_dtcs(status, ecu)` + `lookup_dtc(code)` | DTC drilldown |
+
+### Yamaha-specific decisions
+
+| Quirk | Decision | Rationale |
+|---|---|---|
+| `A_YAM_*` proprietary fields stripped by normalizer | Expose under **original names** (no friendly aliases yet) | Zero new mapping work; agent calls `search_manual` to learn what each means; revisit if evals show stumbling |
+| Yamaha-hex DTCs (`87F11043…`) | **Honest no-decoder + manual pivot** in `lookup_dtc` | No public Yamaha DTC spec; building a decoder is out of scope; manual chart is the realistic recovery path |
+| Channel B (ABS ECU) not materialized in fixture | List as `not present` in `list_signals`; `list_dtcs(ecu="abs")` returns empty cleanly | Future fixtures may include Channel B; interface stable |
+| Freeze-frame data absent | Skip `get_freeze_frame` tool entirely | Defer interface until data exists; lying about an unavailable tool is worse than omitting it |
+
+## Design
+
+### 1. Architecture
+
+```
+                   ┌───────────────────────────────┐
+                   │   Main diagnosis agent        │
+                   │   (12-tool registry)          │
+                   │   primitives + delegation     │
+                   └──────────────┬────────────────┘
+                                  │ delegate_to_obd_agent(inquiry)
+                                  ▼
+┌───────────────────────────────────────────────────────────────┐
+│  OBD sub-agent  (new — app/harness_agents/obd_agent.py)       │
+│  • run_obd_agent(inquiry, session_id, deps) -> OBDAgentResult │
+│  • Restricted ReAct loop, max_iter=8, timeout=120s            │
+│  • Reuses LLMClient + ToolRegistry from app.harness           │
+└──────────────┬────────────────────────────────────────────────┘
+               │  tool calls (only the 6 OBD primitives)
+               ▼
+┌───────────────────────────────────────────────────────────────┐
+│  OBD investigation toolset  (new — app/harness_tools/obd_*.py)│
+│  ├─ list_signals       (Glob analog)                          │
+│  ├─ read_window        (Read analog)                          │
+│  ├─ get_signal_stats   (aggregate primitive)                  │
+│  ├─ find_events        (Grep analog)                          │
+│  ├─ list_dtcs          (DTC enumeration)                      │
+│  └─ lookup_dtc         (DTC decode + manual pivot)            │
+└──────────────┬────────────────────────────────────────────────┘
+               │  reads raw CSV via _resolve_log_path() pattern
+               ▼
+       OBDAnalysisSession.raw_input_file_path on disk
+```
+
+#### Registries (three independent factories)
+
+```python
+create_default_registry()    # Main agent: 12 tools
+                              #   6 OBD primitives + 4 manual primitives
+                              #   + delegate_to_obd_agent
+                              #   + delegate_to_manual_agent
+
+create_obd_agent_registry()  # OBD sub-agent: 6 primitives only
+                              #   (no delegation — prevents recursion)
+
+create_manual_agent_registry() # Manual sub-agent: 3 primitives only
+                                #   (already exists in manual_agent.py)
+```
+
+#### `OBDAgentResult` contract
+
+Mirrors `ManualAgentResult` (`harness_agents/types.py`) where structurally
+identical, diverges only where OBD data differs from manual content.
+
+```python
+class SignalCitation(BaseModel):
+    signal: str
+    time_range: Optional[Tuple[str, str]] = None  # ISO start / end
+    value: Optional[float] = None
+    stat: Optional[str] = None                    # "p95"|"mean"|"max"|...
+    units: Optional[str] = None
+
+class DTCCitation(BaseModel):
+    code: str
+    status: Literal["stored", "pending"]
+    ecu: Optional[str] = None
+
+class DataExcerpt(BaseModel):
+    kind: Literal["stats", "events", "window", "dtcs"]
+    payload: Dict[str, Any]                        # tool-output shape
+
+class OBDAgentResult(BaseModel):
+    summary: str
+    signal_citations: List[SignalCitation]
+    dtc_citations: List[DTCCitation]
+    raw_data: List[DataExcerpt]
+    limitations: List[str]
+    tool_trace: List[ToolCallTrace]                # reused from types.py
+    iterations: int
+    total_tokens: int
+    stopped_reason: StoppedReason                  # reused from types.py
+```
+
+### 2. Tool catalog
+
+All 8 tools return plain text. Inputs are Pydantic-validated; `_session_id` is
+auto-injected by the loop and not declared in the input model.
+
+#### 2.1 `list_signals` (Glob analog, cheap)
+
+**Question:** *"What signals does this OBD log contain?"*
+
+```python
+class ListSignalsInput(BaseModel):
+    pattern: Optional[str] = None
+    subsystem: Optional[Literal["engine", "abs", "all"]] = "all"
+```
+
+Returns ~150-token text inventory: time range, sampling rate, channel
+presence, signal list with units + density (dense / sparse / missing).
+Filters by glob-ish pattern and subsystem.
+
+#### 2.2 `read_window` (Read analog, medium)
+
+**Question:** *"Give me raw samples for these signals in this time range."*
+
+```python
+class ReadWindowInput(BaseModel):
+    signals: List[str] = Field(..., min_length=1, max_length=8)
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    max_rows: int = Field(default=50, ge=1, le=500)
+```
+
+Tab-separated table with timestamp + requested signals. Auto-downsamples
+when window samples exceed `max_rows`. Always shows units + missing-data
+notes.
+
+#### 2.3 `get_signal_stats` (aggregate, cheap)
+
+**Question:** *"Summarize these signals — give me mean/std/percentiles, no
+raw rows."*
+
+```python
+class GetSignalStatsInput(BaseModel):
+    signals: List[str] = Field(..., min_length=1, max_length=10)
+    time_range: Optional[Tuple[str, str]] = None
+    include: Optional[List[Literal[
+        "basic", "percentiles", "trend", "extrema",
+    ]]] = None  # default ["basic", "percentiles"]
+```
+
+Internal implementation **reuses `obd_agent/statistics_extractor.py`** — the
+kind of "primitive helper" #69 wanted preserved (data-producing, not
+conclusion-emitting). With `include=["extrema"]` also returns timestamps of
+min/max — useful for the agent to drill in with `read_window`.
+
+#### 2.4 `find_events` (Grep analog, cheap)
+
+**Question:** *"When does this signal meet this condition?"*
+
+```python
+class FindEventsInput(BaseModel):
+    signal: str
+    predicate: Literal[
+        "above_threshold", "below_threshold",
+        "rising_above", "falling_below",
+        "rate_of_change_above", "rate_of_change_below",
+        "missing",
+    ]
+    threshold: Optional[float] = None
+    min_duration_seconds: float = 1.0
+    merge_gap_seconds: float = 2.0
+    time_range: Optional[Tuple[str, str]] = None
+    max_events: int = Field(default=20, ge=1, le=100)
+```
+
+Returns list of `(start, end, duration, peak, sample_count)` per event.
+Predicates are a fixed enum (safer, more predictable, easier to test) — no
+free-form expressions.
+
+#### 2.5 `list_dtcs` (DTC enumeration, cheap)
+
+**Question:** *"What fault codes are in this session?"*
+
+```python
+class ListDTCsInput(BaseModel):
+    status: Optional[Literal["stored", "pending", "all"]] = "all"
+    ecu: Optional[Literal["engine", "abs", "all"]] = "all"
+```
+
+Extracts standard P-codes from `GET_DTC` / `GET_CURRENT_DTC` columns (existing
+`_parse_dtc_list` path) **and** Yamaha-hex DTCs from the leading metadata
+comment block (new helper). Groups by classification, separates stored vs.
+pending.
+
+#### 2.6 `lookup_dtc` (DTC decode, cheap)
+
+**Question:** *"What does this fault code mean, what subsystem is it about,
+what should I look at next?"*
+
+```python
+class LookupDTCInput(BaseModel):
+    code: str
+```
+
+Standard P/C/B/U codes → python-OBD lookup (existing
+`log_parser.py:159` path). Yamaha hex → honest "no decoder" output with a
+`search_manual(query=<code>, vehicle_model=…)` pivot. Unknown formats → clear
+error string suggesting verification.
+
+#### 2.7 `delegate_to_obd_agent` (delegation wrapper)
+
+**Question (from main agent):** *"Investigate this OBD-related question
+end-to-end; come back with a structured finding."*
+
+```python
+class DelegateToOBDAgentInput(BaseModel):
+    inquiry: str = Field(..., min_length=10, max_length=500)
+```
+
+Handler:
+1. Build `OBDAgentDeps(llm_client, create_obd_agent_registry(), config)`.
+2. Await `run_obd_agent(inquiry, _session_id, deps)` → `OBDAgentResult`.
+3. Serialize via `format_obd_agent_result(result)` → structured markdown
+   (summary + signal_citations + dtc_citations + raw_data + limitations).
+
+`max_result_chars` raised to ~80 KB to accommodate sub-agent outputs.
+
+#### 2.8 `delegate_to_manual_agent` (delegation wrapper)
+
+```python
+class DelegateToManualAgentInput(BaseModel):
+    inquiry: str = Field(..., min_length=10, max_length=500)
+    obd_context: Optional[str] = Field(default=None, max_length=2000)
+```
+
+Pure wrapper over the existing `run_manual_agent` infrastructure. Same
+serialization pattern with `format_manual_agent_result`.
+
+### 3. Data flow + infrastructure
+
+#### 3.1 Raw-data access (no new infrastructure)
+
+Reuse `_resolve_log_path(session_id, db)` + `parse_log_file(path)` already in
+the codebase. Each tool re-parses the CSV on call. Justified for v1 because
+the Yamaha fixture is 257 rows / ~50 KB and parses in < 50 ms. If profiling
+shows it matters, add a per-sub-agent-run `lru_cache` later — single PR,
+no architectural debt.
+
+#### 3.2 `A_YAM_*` field exposure
+
+The new tools **bypass `format_normalizer.py`** (which strips these). They
+read column names directly from `parse_log_file()` output. A new helper
+`obd_signal_inventory.py` produces `SignalDescriptor(name, units, subsystem,
+density)` records. Units for known `A_YAM_*` fields come from a small
+hand-curated dict (`BATT_V` → V, `INJ_MS` → ms, etc.); unknown fields just
+say "raw".
+
+#### 3.3 DTC parsing
+
+```
+list_dtcs / lookup_dtc
+  └─> _extract_dtcs_from_metadata(file_path)  [new helper]
+        ├─ Regex over leading comment block for "Stored DTC:" / "Pending DTC:"
+        │  (Yamaha hex lives there in the fixture)
+        └─ Existing _parse_dtc_list() for GET_DTC / GET_CURRENT_DTC columns
+           (standard P-code path)
+  └─> _classify_dtc(code) → "standard" | "yamaha_hex" | "unknown"
+        ├─ standard → python-OBD table
+        ├─ yamaha_hex → honest no-decoder output
+        └─ unknown → actionable error string
+```
+
+#### 3.4 Sub-agent execution context
+
+Sub-agent **shares the LLMClient** with the main agent (same OpenRouter /
+Ollama backend) but uses an **independent message history** and **restricted
+tool registry**. Failure isolation: a sub-agent timeout returns a graceful
+`OBDAgentResult(stopped_reason="timeout", …)` rather than bubbling up.
+
+#### 3.5 Result formatters
+
+New file `app/harness_agents/result_formatters.py`:
+- `format_obd_agent_result(result) -> str` — markdown serialization for
+  delegation tool output.
+- `format_manual_agent_result(result) -> str` — same for manual.
+
+Lives next to the agent files because it is semantically owned by the
+sub-agent contract, not the tool.
+
+#### 3.6 What does NOT change
+
+- `app/harness/loop.py` — main loop logic unchanged; just sees more tools.
+- `app/harness/context.py` — truncation / compaction logic unchanged.
+- `app/harness/autonomy.py` — tier routing unchanged.
+- `app/harness_agents/manual_agent.py` — manual sub-agent unchanged.
+- DB schema — unchanged.
+- API endpoints — unchanged. (No new standalone OBD sub-agent endpoint in
+  this PR; can be added later when an OBD eval suite exists.)
+
+### 4. Error handling
+
+Anthropic's tool-writing guide is emphatic that errors must be **actionable**.
+Three tiers:
+
+| Tier | Cause | Handler | Example output |
+|---|---|---|---|
+| **T1 — Input validation** | Pydantic rejects the call | Registry catches `ValidationError`, formats into actionable string | "predicate 'above_threshold' requires `threshold` parameter. Example: …" |
+| **T2 — Domain mismatch** | Valid input, signal/code doesn't exist | Tool handler returns descriptive text (NOT raises); `is_error=False` | "Signal 'EGT' not in this session. Did you mean: COOLANT_TEMP, IAT? Use `list_signals` to see all 15 available signals." |
+| **T3 — System / IO failure** | DB unreachable, file missing, sub-agent timeout | Tool handler raises → registry catches → `ToolResult(is_error=True, …)` | "Error: could not read OBD log file for session 7f3b… (file not found). This may be a stale session ID; verify with the user." |
+
+#### Per-tool edge cases (summary)
+
+- **`list_signals`**: corrupt file → informational message, not error.
+- **`read_window`**: unknown signal → fuzzy-match suggestion (Levenshtein over
+  inventory); inverted window → clear message; window outside session
+  bounds → 0-sample notice with session range.
+- **`get_signal_stats`**: <3 valid samples → omit `autocorr` / `linreg` with
+  notes; all N/A in range → `count=0` row (not dropped).
+- **`find_events`**: zero events → include max value in range to help agent
+  adjust threshold; missing threshold for value predicate → T1.
+- **`list_dtcs`**: no DTCs → informational, not error.
+- **`lookup_dtc`**: Yamaha hex → no-decoder output with manual pivot;
+  unrecognized format → "Code 'X1234' is not a recognized OBD-II standard
+  code and does not match Yamaha hex format. Verify the code…"
+- **`delegate_to_*`**: timeout / max_iterations → structured `*AgentResult`
+  with `stopped_reason` set; LLM error → `stopped_reason="error"`.
+
+#### Sub-agent loop error handling
+
+Mirror `manual_agent.py`'s pattern verbatim:
+
+| Failure | Handling |
+|---|---|
+| `asyncio.timeout` | Catch → `stopped_reason="timeout"`, preserve partial state |
+| Max iterations | While-else → `stopped_reason="max_iterations"` |
+| LLM JSON parse failure | Fallback: `_extract_last_assistant_content`, empty citations |
+| Tool exec error | Surface error string via registry; sub-agent keeps iterating |
+| Tool argument parse error | Append clean error as tool result so LLM self-corrects |
+
+#### Privacy boundary
+
+Per CLAUDE.md "Privacy & Data Boundaries (Non-Negotiable)":
+
+- `read_window` enforces `max_rows ≤ 500` via Pydantic — prevents log dump.
+- `get_signal_stats` only returns aggregates.
+- `find_events` returns event metadata (start / end / peak), never the
+  underlying sample sequences.
+- `OBDAgentResult.raw_data` excerpts are bounded by the same caps because
+  they are built from these tool outputs.
+
+VINs: existing `pseudonymise_vin()` policy still applies but is dormant on
+this hot path per APP-54. No new handling required.
+
+### 5. Testing strategy
+
+Per issue #85: "Smoke-test all tools against the real road-test fixture.
+Tool registration in the harness, basic unit tests." Diagnostic-accuracy
+evals are out of scope.
+
+#### 5.1 Three test layers
+
+| Layer | What it tests | Where | Network / LLM? |
+|---|---|---|---|
+| Unit | Each tool against the Yamaha fixture | `tests/harness_tools/test_obd_*.py` | No |
+| Sub-agent smoke | `run_obd_agent` end-to-end with mocked LLM | `tests/harness_agents/test_obd_agent.py` | No |
+| Delegation smoke | `delegate_to_*` handlers wired into the registry | `tests/harness_tools/test_delegation_tools.py` | No |
+
+#### 5.2 Coverage targets (~35-40 new tests)
+
+- `test_obd_signals.py` — 5 classes (List/Read/Stats/Events/Inventory)
+- `test_obd_dtcs.py` — 2 classes (List / Lookup)
+- `test_obd_agent.py` — sub-agent ReAct flow, timeout, max_iter, JSON
+  failure, tool-error recovery
+- `test_delegation_tools.py` — registry dispatch, session_id injection,
+  formatted output, recursion guard (sub-agent registry MUST NOT contain
+  delegation tools)
+
+Specific must-have unit tests:
+
+- `test_list_signals_returns_a_yam_proprietary_signals_under_original_names`
+  — validates locked decision.
+- `test_list_dtcs_extracts_two_yamaha_hex_dtcs_from_fixture_metadata` —
+  uses real fixture data.
+- `test_lookup_dtc_yamaha_hex_returns_no_decoder_with_manual_pivot` —
+  validates locked decision.
+- `test_read_window_unknown_signal_returns_fuzzy_match_suggestion` —
+  T2 validation.
+- `test_get_signal_stats_basic_stats_match_statistics_extractor_output` —
+  reuse verification.
+- `test_no_recursion_obd_agent_cannot_call_delegate_tool` — registry
+  isolation.
+
+#### 5.3 What is NOT tested in this PR
+
+- **Diagnostic accuracy / correctness of agent conclusions** — out of scope.
+- **Production main-agent integration regression** — covered by existing
+  `test_integration.py` and `test_e2e_agent.py`. Run as-is; fix any fallout
+  from the main registry growing from 5 to 12 tools.
+- **Performance** — Yamaha fixture is small; defer caching decisions.
+- **Multi-vehicle generalization** — Yamaha-only.
+
+## Files to create / modify
+
+| File | Action | LOC est. |
+|---|---|---|
+| `app/harness_agents/obd_agent.py` | Create — sub-agent ReAct loop | ~600 |
+| `app/harness_agents/obd_agent_prompts.py` | Create — system prompt + user message | ~120 |
+| `app/harness_agents/types.py` | Modify — add `SignalCitation`, `DTCCitation`, `DataExcerpt`, `OBDAgentResult` | +60 |
+| `app/harness_agents/result_formatters.py` | Create — `format_obd_agent_result`, `format_manual_agent_result` | ~150 |
+| `app/harness_tools/obd_signals.py` | Create — 4 signal tools | ~500 |
+| `app/harness_tools/obd_dtcs.py` | Create — 2 DTC tools | ~250 |
+| `app/harness_tools/obd_signal_inventory.py` | Create — `SignalDescriptor` + classifier helpers | ~120 |
+| `app/harness_tools/delegation_tools.py` | Create — `delegate_to_obd_agent` + `delegate_to_manual_agent` | ~180 |
+| `app/harness_tools/input_models.py` | Modify — 6 OBD input models + 2 delegation input models | +120 |
+| `app/harness/tool_registry.py` | Modify — `create_default_registry` swap, new `create_obd_agent_registry` | +50 |
+| `app/harness/harness_prompts.py` | Modify — tool descriptions + delegation guidance | +60 |
+| `app/harness_tools/obd_data_tools.py` | Modify — unregister `read_obd_data` from default registry; keep file for one cycle | -10 |
+| `tests/harness_tools/test_obd_signals.py` | Create | ~400 |
+| `tests/harness_tools/test_obd_dtcs.py` | Create | ~200 |
+| `tests/harness_tools/test_delegation_tools.py` | Create | ~200 |
+| `tests/harness_agents/test_obd_agent.py` | Create | ~350 |
+
+Net addition: ~3,200 LOC including tests.
+
+## Open questions / future work
+
+These are deliberately deferred to follow-up tickets but worth recording:
+
+1. **`delegate_to_obd_agent` vs. direct OBD tools — when does main agent
+   pick which?** Initial system-prompt guidance: "Use primitive tools for
+   focused questions; delegate for compound investigations." If
+   in-production traces show the main agent over- or under-delegating, tune
+   the prompt or surface confidence-based routing.
+
+2. **Per-run DataFrame cache.** Single PR refactor when profiling shows
+   per-call CSV parsing is the bottleneck.
+
+3. **Yamaha-hex DTC decoder.** Needs Yamaha spec or careful reverse-engineering.
+   Until then, `lookup_dtc` honestly says "no decoder; check the manual."
+
+4. **OBD eval suite.** Parallel to #73 for manuals. Blocked on having
+   labelled fault data — pending real-world cases from the PolyU pilot.
+
+5. **A_YAM_\* friendly aliases.** If evals show the agent stumbles on
+   proprietary field names (e.g. confusing `A_YAM_VVA` with valve angle vs.
+   variable valve actuator), build a friendly-name map. Otherwise the
+   agent calls `search_manual` to learn what each means.
+
+6. **Main agent → pure-orchestrator rewrite (Pattern 3).** Long-term
+   direction. Triggered when delegation traces show the main agent rarely
+   uses primitives directly. Separate ticket.
+
+7. **Freeze-frame tool.** Once a fixture with freeze-frame data exists,
+   add `get_freeze_frame(dtc_code?)`.
+
+8. **Channel B (ABS ECU) data.** Currently `list_signals` reports "not
+   present" for the Yamaha fixture. When CAN-side data appears in future
+   uploads, the existing tools should handle it transparently.
+
+## References
+
+- Issue [#85 — HARNESS-19 (this ticket)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/85)
+- Issue [#69 — V2 toolset redesign (`read_obd_data` lineage)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/69)
+- Issue [#71 — Manual toolset (reference pattern for 3-tool decomposition)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/71)
+- Issue [#73 — Manual sub-agent eval suite (`ManualAgentResult` contract)](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/73)
+- Issue [#80 — Yamaha real-road-test regression fixture](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/80)
+- Issue [#26 — Harness engineering architecture](https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/26)
+- [Anthropic — Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)
+- [Anthropic — Develop your tests](https://platform.claude.com/docs/en/test-and-evaluate/develop-tests)
+- `app/harness_agents/manual_agent.py` — template for the OBD sub-agent
+- `docs/v2_design_doc.md` — V2 architecture (will be updated when this PR lands)
+- `docs/v2_dev_plan.md` — V2 dev plan (HARNESS-19 ticket entry will be added)


### PR DESCRIPTION
**Re-opened replacement for #92 which GitHub auto-closed when its original base branch \`harness-19/01-design-types\` was deleted on merge of #91.** Same branch, same commits.

## Summary

Second in the 5-PR chain. Adds the data layer the rest of the toolset sits on. No agent-side wiring yet.

## Why bypass \`format_normalizer.py\`

The legacy normalizer strips all \`A_YAM_*\` Yamaha proprietary columns. Per the HARNESS-19 locked decision the agent must see these signals, so this loader reads the raw uploaded bytes directly and preserves every column.

## Files

- \`app/harness_tools/obd_loader.py\` — Yamaha-dual CSV + standard OBD TSV detection, UTF-8 BOM defense, DTC extraction from \`#\`-metadata block.
- \`app/harness_tools/obd_signal_inventory.py\` — \`SignalDescriptor\` with units + density + subsystem; curated unit map for 16 known Yamaha proprietary signals; fuzzy-match suggestions.

## Test plan

- [x] 27 unit tests against the real Yamaha road-test fixture (\`yamaha_dual_road_test_20260508.csv\` from #80).
- [x] BOM defense verified.
- [x] 16 A_YAM_* columns preserved.
- [x] 2 metadata DTCs surfaced (stored + pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)