### PR TITLE
fix(eval): repair test_manual_agent_eval collection after judge rewrite

### DIFF
--- a/diagnostic_api/tests/harness/evals/test_manual_agent_eval.py
+++ b/diagnostic_api/tests/harness/evals/test_manual_agent_eval.py
@@ -34,8 +34,8 @@ from tests.harness.evals.conftest import (
     EvalReport,
     load_golden,
 )
-from tests.harness.evals.judge import judge_result
-from tests.harness.evals.runner import run_manual_agent
+from tests.harness.evals.judge import grade_run
+from tests.harness.evals.runner import run_manual_agent_unified
 from tests.harness.evals.schemas import GoldenEntry
 
 
@@ -48,17 +48,38 @@ _PASS_THRESHOLD = 0.7
 # Load goldens at import time so pytest parametrization shows one
 # test id per entry.  HARNESS-20: the locked tier is the canonical
 # source — promote_golden.py is the only way an entry lands here.
-# An empty file means "no entries yet promoted", which collects
-# to zero tests (cleanly skipped) rather than a collection error.
 _LOCKED_ENTRIES = load_golden("v2/locked/mws150a.jsonl")
+
+# An empty locked file is the shipped initial state (no entries
+# promoted yet).  Parametrising on an empty list crashes pytest's
+# ``ids=lambda`` evaluator, so substitute a single skipped
+# placeholder that explains how to populate the tier — gives a
+# clean "1 skipped" line instead of a collection error.
+_NO_LOCKED_REASON = (
+    "No entries in golden/v2/locked/mws150a.jsonl yet.  Promote "
+    "candidates via `python -m scripts.promote_golden "
+    "--entry-id <id> --reviewer <name> --reason <why>` "
+    "(HARNESS-20)."
+)
+_PARAM_ENTRIES = (
+    _LOCKED_ENTRIES
+    if _LOCKED_ENTRIES
+    else [
+        pytest.param(
+            None,
+            id="no-locked-entries",
+            marks=pytest.mark.skip(reason=_NO_LOCKED_REASON),
+        ),
+    ]
+)
 
 
 @pytest.mark.eval
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "entry",
-    _LOCKED_ENTRIES,
-    ids=lambda e: e.id,
+    _PARAM_ENTRIES,
+    ids=lambda e: e.id if _LOCKED_ENTRIES else None,
 )
 async def test_manual_agent(
     entry: GoldenEntry,
@@ -78,12 +99,18 @@ async def test_manual_agent(
             local Ollama, or a stub deps object when
             ``--mock-agent`` is passed.
     """
-    result = await run_manual_agent(
+    # Mirror the OBD eval's pattern: produce a unified
+    # SystemRunResult so the shared judge (grade_run) can grade
+    # the manual agent and RAG on the same rubric.  The legacy
+    # judge_result helper that took a ManualAgentResult directly
+    # was removed during HARNESS-21's judge rewrite when the
+    # grader was generalised across systems.
+    run = await run_manual_agent_unified(
         entry.question, entry.obd_context,
         deps=manual_agent_deps,
     )
-    grade = await judge_result(entry, result, client=judge_client)
-    eval_report.record(entry, result, grade)
+    grade = await grade_run(entry, run, client=judge_client)
+    eval_report.record(entry, run, grade)  # type: ignore[arg-type]
 
     assert grade.overall >= _PASS_THRESHOLD, (
         f"[{entry.id}] overall={grade.overall:.2f} "


### PR DESCRIPTION
## Summary
- The eval entry point imports `judge_result` from `tests.harness.evals.judge`, but that helper was removed during HARNESS-21's judge rewrite. The replacement is `grade_run` paired with the unified runner `run_manual_agent_unified` — exactly what `test_obd_agent_eval.py` already uses.
- This commit ports the manual eval test to the unified pattern, so both lanes call the same grader through the same `SystemRunResult` shape.
- Adds an empty-tier safety net for the HARNESS-20 locked file: parametrising on an empty list crashes pytest's `ids=lambda` evaluator, so a single skipped placeholder substitutes when no entries have been promoted yet. Result is a clean `1 skipped` with a clear message pointing at `scripts/promote_golden.py`.

## Stacking
**This PR is stacked on `harness-20-golden-lockin` (PR #102).** Base must stay set to `harness-20-golden-lockin` until #102 merges; then retarget to `main` before #102's branch is deleted. (Pattern noted in PR-workflow feedback.)

## Why this surfaced now
HARNESS-20 (#102) flipped the eval suite from `v1/mws150a.jsonl` (which loaded 10 dummy entries) to `v2/locked/mws150a.jsonl` (empty by design). The empty list exposed two latent issues:
1. The stale `judge_result` import — present since HARNESS-21 but masked by the v1 path successfully loading entries (the file-level collection error was thrown after parametrize ran, so users would have hit it only when actually trying to run an eval).
2. Pytest's `ids=lambda` evaluator tripping on an empty parametrize list.

## What is NOT changing
- No production code touched.
- No change to the judge or runner modules — both already had the right surface; only the test caller was stale.
- No change to the eval rubric, weights, or pass threshold.

## Test plan
- [x] `pytest --collect-only tests/harness/evals/test_manual_agent_eval.py` → `1 test collected` (was `1 error`)
- [x] `pytest tests/harness/evals/test_manual_agent_eval.py` → `1 skipped` (clean reason: "No entries in golden/v2/locked/mws150a.jsonl yet...")
- [x] `pytest tests/harness/evals/test_manual_agent_eval.py --run-eval` → same `1 skipped` (the `skip` mark on the placeholder param overrides the eval gate, by design — there's nothing real to run)
- [x] No regression in HARNESS-20 tests: `pytest tests/scripts/test_promote_golden.py tests/test_golden_sync.py` still passes 24/24
- [ ] **After at least one entry is promoted**: the placeholder branch is bypassed and the real parametrize runs against the locked entries

Closes the follow-up flagged in PR #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)