### PR TITLE
HARNESS-20 phase 3 prep: RAG eval lane + ready-to-run baseline plan

### DIFF
--- a/diagnostic_api/tests/harness/evals/test_rag_eval.py
+++ b/diagnostic_api/tests/harness/evals/test_rag_eval.py
@@ -1,0 +1,123 @@
+"""Parametrized entry point for the RAG eval lane (HARNESS-20 phase 3).
+
+Mirror of ``test_manual_agent_eval.py`` for the RAG retriever.
+Same locked-tier source (`golden/v2/locked/mws150a.jsonl`), same
+LLM judge (`grade_run` via z-ai/glm-5.1), same `Grade` envelope.
+
+Lets the eval suite produce an **agent-vs-RAG** comparison
+without changing the manual-agent suite — both files write into
+the same session-scoped ``eval_report`` fixture, so a single
+pytest invocation grades both lanes against the same 30 goldens
+and the resulting JSON report carries both sets of grades.
+
+Why a separate file (instead of parametrising the existing file
+over an extra `system` axis): the agent lane has its own
+mock-agent CLI flag + fixture; the RAG lane needs neither (it
+takes no `deps` parameter, just calls `retrieve_context`
+directly). Forking the file keeps each lane's parametrize axis
+focused on `entry` only and keeps mock plumbing per-lane.
+
+Run both lanes against the locked corpus::
+
+    pytest --run-eval \\
+        tests/harness/evals/test_manual_agent_eval.py \\
+        tests/harness/evals/test_rag_eval.py
+
+Author: Li-Ta Hsu
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from tests.harness.evals.conftest import (
+    EvalReport,
+    load_golden,
+)
+from tests.harness.evals.judge import grade_run
+from tests.harness.evals.rag_runner import run_rag
+from tests.harness.evals.schemas import GoldenEntry
+
+
+# Minimum overall score the RAG lane must achieve.  Held at the
+# same value as the agent lane for the first baseline — phase 3
+# will lower BOTH to a justified number after seeing real data.
+# Hard-failing on this threshold is intentional: it makes the
+# CI / pytest output mirror the agent lane and prevents a
+# silent regression from sneaking in once a baseline exists.
+_PASS_THRESHOLD = 0.7
+
+
+# Load goldens at import time so pytest parametrization shows one
+# test id per entry.  Same empty-tier safety net as the agent
+# lane: a single skipped placeholder when no entries have been
+# promoted yet, instead of a parametrize-with-empty-list
+# collection crash.
+_LOCKED_ENTRIES = load_golden("v2/locked/mws150a.jsonl")
+
+_NO_LOCKED_REASON = (
+    "No entries in golden/v2/locked/mws150a.jsonl yet.  Promote "
+    "candidates via `python -m scripts.promote_golden "
+    "--entry-id <id> --reviewer <name> --reason <why>` "
+    "(HARNESS-20)."
+)
+_PARAM_ENTRIES = (
+    _LOCKED_ENTRIES
+    if _LOCKED_ENTRIES
+    else [
+        pytest.param(
+            None,
+            id="no-locked-entries",
+            marks=pytest.mark.skip(reason=_NO_LOCKED_REASON),
+        ),
+    ]
+)
+
+
+# RAG-side knobs.  ``top_k=5`` matches the production endpoint
+# default.  ``vehicle_model="MWS150-A"`` filters to the single
+# manual currently ingested — bumping the corpus to multiple
+# manuals would lift this to a parametrize axis (recall@k per
+# manual scope).
+_RAG_TOP_K = 5
+_RAG_VEHICLE_MODEL = "MWS150-A"
+
+
+@pytest.mark.eval
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "entry",
+    _PARAM_ENTRIES,
+    ids=lambda e: e.id if _LOCKED_ENTRIES else None,
+)
+async def test_rag(
+    entry: GoldenEntry,
+    eval_report: EvalReport,
+    judge_client: Optional[Any],
+) -> None:
+    """Run RAG retrieval and grade it against the golden entry.
+
+    Args:
+        entry: One ``GoldenEntry`` from
+            ``golden/v2/locked/mws150a.jsonl``.
+        eval_report: Session-scoped report accumulator.  Shared
+            with the agent lane so a single pytest invocation
+            produces one combined report covering both systems.
+        judge_client: ``None`` for the real GLM 5.1 judge, or a
+            mock client when ``--mock-judge`` is passed.
+    """
+    run = await run_rag(
+        question=entry.question,
+        top_k=_RAG_TOP_K,
+        vehicle_model=_RAG_VEHICLE_MODEL,
+    )
+    grade = await grade_run(entry, run, client=judge_client)
+    eval_report.record(entry, run, grade)  # type: ignore[arg-type]
+
+    assert grade.overall >= _PASS_THRESHOLD, (
+        f"[{entry.id} / rag] overall={grade.overall:.2f} "
+        f"below threshold {_PASS_THRESHOLD}: "
+        f"{grade.reasoning}"
+    )

--- a/docs/harness_14_phase6_baseline.md
+++ b/docs/harness_14_phase6_baseline.md
@@ -1,0 +1,152 @@
+# HARNESS-14 Phase 6 Baseline — Manual Agent vs RAG on Locked Goldens
+
+**Status:** Planned (no run executed yet)
+**Owner:** Li-Ta Hsu
+**Date:** 2026-05-24
+**Goldens:** `tests/harness/evals/golden/v2/locked/mws150a.jsonl` — 30 expert-approved entries (5★ accept from Towngas workshop expert; promoted via `scripts/promote_golden.py` in HARNESS-20 phase 2, PR #104)
+**Judge:** `z-ai/glm-5.1` via OpenRouter (HK-accessible per #23)
+**Agent under test:** local `qwen3.5:27b-q8_0` (production model)
+**Comparison system:** pgvector RAG retrieval (`top_k=5`, `vehicle_model="MWS150-A"`)
+
+---
+
+## What this doc is for
+
+This is a **pre-run baseline plan**, not a results writeup. It captures everything needed to execute the first agent-vs-RAG comparative eval on the post-HARNESS-20 corpus, plus the gotchas discovered during plumbing validation. The actual results doc lands as `harness_14_phase6_baseline_results.md` after the run.
+
+The work split:
+
+| Phase | Action | Status |
+|---|---|---|
+| 1 (PR #102) | Two-tier corpus + promote script | ✅ MERGED |
+| 2 (PR #104) | Retro-lock 30 expert-approved candidates | ✅ MERGED |
+| 3 (this PR) | RAG eval lane + this baseline plan + procedural gotchas | 🔧 IN PROGRESS |
+| First baseline run | Execute the procedure below + capture results | ⏸ DEFERRED (user paused) |
+| Threshold pin + results doc | Lower `_PASS_THRESHOLD` per real data; ship `phase6_baseline_results.md` | ⏸ DEFERRED |
+
+---
+
+## Procedure (ready to run)
+
+### Pre-run checks
+
+```bash
+# 1. Confirm server is at the post-phase-2 commit
+ssh polyu-gpu "cd ~/stf_ai_diagnosis_platform_v1 && git log --oneline -1"
+# Expect: a commit whose tree contains golden/v2/locked/mws150a.jsonl with 30 lines
+
+# 2. Confirm 30 lines in the locked file
+ssh polyu-gpu "podman exec stf-diagnostic-api wc -l \
+  /app/tests/harness/evals/golden/v2/locked/mws150a.jsonl"
+# Expect: 30
+
+# 3. Confirm Ollama serves qwen3.5:27b-q8_0
+ssh polyu-gpu "curl -s http://127.0.0.1:11434/api/tags | grep qwen3.5:27b"
+# Expect: a model entry
+
+# 4. Confirm OpenRouter key + GLM-5.1 reachable
+ssh polyu-gpu "grep PREMIUM_LLM_API_KEY ~/stf_ai_diagnosis_platform_v1/infra/.env | wc -l"
+# Expect: 1
+```
+
+### Run command
+
+```bash
+# Mount tests/ + scripts/ INTO a one-shot container built from the
+# diagnostic-api image (the image itself ships only golden/v2/, not
+# the test files — see Dockerfile line 61 comment).
+#
+# CRITICAL: mount tests/ RW (not :ro) — the eval_report fixture
+# writes reports/eval_{timestamp}.json at teardown.  Read-only
+# mount errors with "Read-only file system" right before exit
+# and you lose the report.
+ssh polyu-gpu "podman run --rm \
+  -v ~/stf_ai_diagnosis_platform_v1/diagnostic_api/tests:/app/tests \
+  -v ~/stf_ai_diagnosis_platform_v1/diagnostic_api/scripts:/app/scripts:ro \
+  -e PYTHONPATH=/app \
+  --env-file ~/stf_ai_diagnosis_platform_v1/infra/.env \
+  --network host \
+  localhost/stf-diagnostic-api:0.1.0 \
+  pytest --run-eval \
+    /app/tests/harness/evals/test_manual_agent_eval.py \
+    /app/tests/harness/evals/test_rag_eval.py \
+    --tb=short 2>&1 | tee /tmp/eval_phase6_baseline.log"
+```
+
+### Capture artifacts
+
+```bash
+# Pull the report JSON back from the server for analysis
+ssh polyu-gpu "ls -t ~/stf_ai_diagnosis_platform_v1/diagnostic_api/tests/harness/evals/reports/*.json | head -1"
+# → /home/talon/.../reports/eval_{ts}.json
+
+scp polyu-gpu:~/stf_ai_diagnosis_platform_v1/diagnostic_api/tests/harness/evals/reports/eval_{ts}.json \
+  ./docs/eval-reports/phase6_baseline_eval.json
+```
+
+---
+
+## Expected cost + time
+
+| Lane | Per-entry latency | Per-entry cost | 30-entry total |
+|---|---|---|---|
+| Manual agent | 60-180s (1-8 tool iterations × Ollama local) | ~$0.005 (judge only) | 30-90 min, ~$0.15 |
+| RAG | <2s (pgvector + judge) | ~$0.005 (judge only) | <2 min, ~$0.15 |
+| **Combined** | — | — | **~30-90 min, ~$0.30** |
+
+Cost dominated by the judge (GLM-5.1 at ~$1.5/1M tokens, ~3K context + ~500 output per call). Agent inference is free (local Ollama, GPU-bound). Latency dominated by the manual agent's multi-iteration loop.
+
+---
+
+## Pre-run decisions (already locked in this PR)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Eval scope | Both `manual_agent` AND `rag` lanes | The publishable artifact (#74) is the comparison. Running only one gets half the story. |
+| Hard-fail on threshold | Yes — keep at `_PASS_THRESHOLD = 0.7` for the first run | The eval_report fixture writes the JSON BEFORE the asserts run, so all 30 grades are captured even when individual asserts fail. Exit code is non-zero; we look at the JSON. Pin a realistic threshold in a follow-up after seeing real data. |
+| Pass threshold revision | Deferred to results PR | Need real numbers to justify the pin. |
+| RAG top-k | 5 (production default) | Matches what `/v2/obd/.../diagnose` requests. Larger k (`10`, `20`) for recall@k curves is a separate ticket. |
+| RAG vehicle filter | `MWS150-A` | Only manual currently ingested. Cross-manual scope expands when a second manual lands. |
+| Shared `eval_report` | Yes — one combined report covers both lanes | Both test files write into the same session-scoped fixture; a single pytest invocation produces one JSON with grades for both systems against the same 30 entries. Enables direct comparison per entry. |
+
+---
+
+## Gotchas discovered during plumbing validation (2026-05-24)
+
+These bit me during the smoke test; documenting so the real run doesn't re-stumble:
+
+1. **Test files are NOT in the container image.** `diagnostic_api/Dockerfile` line 61 comment confirms this is deliberate (test code shouldn't ship to production). The mount-tests-in command above is the workaround. Don't try to `podman exec stf-diagnostic-api pytest ...` — it'll error with "no tests collected".
+
+2. **Reports dir needs RW mount.** Mounted `:ro` errors at teardown with `OSError: [Errno 30] Read-only file system: '.../reports/eval_*.json'`. The grades from EVERY entry are lost (the fixture writes once at the end). Mount as RW.
+
+3. **Mock plumbing doesn't validate real grading.** `--mock-agent --mock-judge` confirms the pipeline runs but produces nonsense scores (mock agent has no real citations → fact_recall=0, section_recall=0). Useful for "does pytest collect + run + report?" but not for "is the agent good?".
+
+4. **Container restart re-runs `golden_sync`.** If you ever edit `golden/v2/*.jsonl` while the API is up, `podman restart stf-diagnostic-api` to re-mirror into the DB. Locked tier is read by the eval harness directly from the filesystem (no restart needed for eval changes).
+
+5. **Pre-existing DB schema bug (HARNESS-20 phase 1).** `golden_sync` walks both tiers but the primary-key-on-id-only schema means the candidate row overwrites the locked row in the DB. Net: `golden_entries.tier` always reads `'candidate'` for the 30 entries. **Does NOT affect this eval** because the eval reads JSONL from the filesystem, not from the DB. Flagged as a separate follow-up.
+
+6. **Stale `_PASS_THRESHOLD = 0.7`.** Hardcoded for stub-perfect plumbing tests. Real Qwen3.5:27b numbers will likely fall in 0.4-0.6. Keeping it at 0.7 for the baseline run is INTENTIONAL — see the table above for the rationale (JSON gets captured anyway).
+
+---
+
+## What to do after the run
+
+1. **Inspect the JSON report** — focus on per-entry `Grade.overall` distribution, per-`question_type` (`lookup`, `procedural`, `cross-section`, `image-required`, `adversarial`) breakdown, and the deterministic-metric subscores (`section_recall`, `fact_recall`, `claim_precision`).
+
+2. **Categorise failures into agent error / judge error / golden bug** — the 3-bucket attribution model from HARNESS-14 phase 5 (`docs/harness_14_phase5_baseline.md`). If a category has >2 "judge error" or "golden bug" entries, fix those before re-baselining — otherwise the threshold pin will encode the bug.
+
+3. **Pick the threshold** — typical rule-of-thumb: `mean(overall) - 1·stdev(overall)` rounded down to one decimal. Gives a floor that catches regressions without being noisy. Pin in both `test_manual_agent_eval.py:_PASS_THRESHOLD` and `test_rag_eval.py:_PASS_THRESHOLD`. They CAN be different per lane if the comparison shows a structural gap.
+
+4. **Write `docs/harness_14_phase6_baseline_results.md`** — header (date, models, commit SHA), per-lane summary table, per-category breakdown, comparison findings ("agent beats RAG by +N on procedural; RAG matches agent on lookup"), known limitations, recommendations.
+
+5. **Open the results PR** with the threshold change + the results doc. Reference the captured JSON in `docs/eval-reports/` (or whichever path the team picks for eval artifacts).
+
+---
+
+## Related
+
+- HARNESS-14 / #73: original eval suite design
+- HARNESS-20 / #90: two-tier corpus + lock-in
+- #74: agent-vs-RAG comparative benchmark (the downstream consumer this baseline feeds)
+- HARNESS-21 / #97: parallel OBD eval lane (separate fixture, same judge)
+- `docs/harness_14_phase5_baseline.md`: the v1-corpus baseline this supersedes


### PR DESCRIPTION
## Summary
- New `tests/harness/evals/test_rag_eval.py` — mirror of `test_manual_agent_eval.py` for the RAG retriever lane. Same locked-tier source, same judge, same `Grade` envelope. Both files write into the shared session-scoped `eval_report` fixture so one pytest invocation produces a combined report covering both lanes against the same 30 entries.
- New `docs/harness_14_phase6_baseline.md` — pre-run plan with the exact `podman run` command, expected cost (~\$0.30 OpenRouter) and latency (30-90 min), the gotchas surfaced during plumbing validation, and the post-run procedure for picking the threshold + writing the results doc.
- **No baseline run executed in this PR.** Plumbing validated end-to-end on 2026-05-24 (mocked smoke against all 30 locked entries); the real run is deferred pending review of this PR. Everything needed to kick it off is in the baseline doc — should be a single ssh command after merge.

## Why prep, not results
Per user decision after the plumbing-smoke completed cleanly: pause the real eval run to give the prep work a review pass before spending OpenRouter credit + ~1h wall clock. This PR is what unblocks the run; the results PR comes after.

## What's NOT in this PR (deliberate)
- The actual baseline run (it's a one-line ssh command in the baseline doc)
- Lowered `_PASS_THRESHOLD` (no data yet to justify a specific number; results PR pins it based on real distribution)
- `docs/harness_14_phase6_baseline_results.md` (lands with the results PR)
- An aggregator that summarises the JSON report into a per-category table (do as a one-off script first; formalise only if it becomes recurring)

## Test plan
- [x] `pytest --collect-only tests/harness/evals/test_rag_eval.py` → 30 tests collected (parametrised over the 30 locked entries)
- [x] Same empty-tier safety net as the manual lane: single skipped placeholder if locked file ever becomes empty, no parametrize-with-empty-list collection crash
- [x] Plumbing smoke on server (mocked agent + mocked judge): pipeline runs end-to-end, eval_report fixture invoked, all 30 entries graded
- [ ] **After merge**: run the procedure in `docs/harness_14_phase6_baseline.md` against the deployed server (cost ~\$0.30, latency 30-90 min)
- [ ] **Results PR**: lower `_PASS_THRESHOLD` per real distribution, commit `harness_14_phase6_baseline_results.md` with per-lane + per-category scorecards

## Gotchas captured in the baseline doc (so the next person doesn't re-discover them)
1. Test files are NOT in the container image by design — must mount tests/ in (the doc has the right `podman run` invocation)
2. reports/ MUST be RW-mounted or grades are lost at teardown (the eval_report fixture writes ONCE at session end)
3. Mock plumbing doesn't validate real grading — useful for "does pytest collect + run?" only
4. Pre-existing HARNESS-20-phase-1 DB schema bug (sole-PK on id, locked-tier upsert overwritten by candidate) does NOT affect this eval since the eval reads JSONL from the filesystem, not from the DB. Flagged as separate follow-up.
5. Hardcoded `_PASS_THRESHOLD = 0.7` is INTENTIONAL for the first run — the eval_report fixture writes the JSON BEFORE asserts run, so even hard-failed entries land their grade. Pytest exits non-zero; we read the JSON anyway.

## Stacking
**No stacking** — this PR targets `main` directly. PRs #102, #103, #104 are all merged.

## Closes / follows
- Continues HARNESS-20 (closed via #102/#103/#104)
- Sets up data needed for #74 (agent-vs-RAG comparative benchmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)