### PR TITLE
hotfix(ui): narrow manual listing's GoldenBucket → ManualGoldenBucket

### DIFF
--- a/obd-ui/src/app/goldens/manual/page.tsx
+++ b/obd-ui/src/app/goldens/manual/page.tsx
@@ -23,12 +23,12 @@ import { Select } from "@/components/ui/select";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { listGoldens } from "@/lib/api";
 import type {
-  GoldenBucket,
+  ManualGoldenBucket,
   GoldenEntrySummary,
   GoldenReviewStatus,
 } from "@/lib/types";
 
-const BUCKETS: GoldenBucket[] = [
+const BUCKETS: ManualGoldenBucket[] = [
   "lookup",
   "procedural",
   "cross-section",
@@ -105,7 +105,7 @@ export default function GoldensListingPage() {
       bucket:
         bucketFilter === "all"
           ? undefined
-          : (bucketFilter as GoldenBucket),
+          : (bucketFilter as ManualGoldenBucket),
       limit: 200,
     })
       .then((res) => setItems(res.items))
@@ -116,7 +116,7 @@ export default function GoldensListingPage() {
   }, [bucketFilter]);
 
   const grouped = useMemo(() => {
-    const out: Record<GoldenBucket, GoldenEntrySummary[]> = {
+    const out: Record<ManualGoldenBucket, GoldenEntrySummary[]> = {
       lookup: [],
       procedural: [],
       "cross-section": [],


### PR DESCRIPTION
PR [2b/4] (#110) build broke the Next.js compile because widening `GoldenBucket` to the union of manual + OBD lane buckets (11 values) made the manual listing's `Record<GoldenBucket, ...>` accumulator require all 11 keys, while it only declares the 5 manual ones.

Fix: switch the manual listing to use `ManualGoldenBucket` (the narrowed manual-only literal type I added in PR [2b/4]). OBD listing already uses `OBDGoldenBucket` correctly. 4 substitutions, 1 file.

```
./src/app/goldens/manual/page.tsx:119:11
Type error: Type '{ lookup: never[]; procedural: never[]; ... adversarial: never[]; }' is missing the following properties from type 'Record<GoldenBucket, GoldenEntrySummary[]>': signal_statistics, event_finding, dtc_enumeration, dtc_decode, and 2 more.
```

Caught during the post-merge deploy of #110 when `npm run build` failed. No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)