### PR TITLE
hotfix(ui): TS-narrow question_type cast in manual grouped loop

### DIFF
--- a/obd-ui/src/app/goldens/manual/page.tsx
+++ b/obd-ui/src/app/goldens/manual/page.tsx
@@ -124,7 +124,13 @@ export default function GoldensListingPage() {
       adversarial: [],
     };
     for (const item of items) {
-      out[item.question_type].push(item);
+      // Cast is safe because listGoldens({lane: "manual"}) only
+      // returns manual-lane entries.  TypeScript can't infer
+      // that from the API call so we narrow explicitly.
+      const bucket = item.question_type as ManualGoldenBucket;
+      if (bucket in out) {
+        out[bucket].push(item);
+      }
     }
     return out;
   }, [items]);


### PR DESCRIPTION
Follow-up to #111. Fixes the second build error from the same Record-narrowing change. Manual listing's  indexed with a wider type than the Record declared; explicit cast + 'bucket in out' guard matches the OBD listing pattern.