### PR TITLE
hotfix(sync): make golden_citations optional for OBD-lane entries

### DIFF
--- a/diagnostic_api/app/services/golden_sync.py
+++ b/diagnostic_api/app/services/golden_sync.py
@@ -174,16 +174,37 @@ def _extract_entry_fields(
         )
         return None
 
-    # Required fields — bail with a warning if missing.
-    # ``golden_citations`` is required for manual entries but is
-    # always ``[]`` for OBD entries (which have native
-    # signal/DTC citations instead).  We still expect the field
-    # to be present in the JSONL to keep the schema explicit.
+    # Required fields — bail with a warning if missing.  Note
+    # that ``golden_citations`` is required for **manual** entries
+    # (the manual eval rubric grades against slug citations) but
+    # is meaningfully empty for **OBD** entries (which carry
+    # signal/DTC citations in their own fields).  We check the
+    # question_type first to decide whether golden_citations is
+    # required, defaulting OBD entries to ``[]`` so authors don't
+    # need to spell out the empty list.
+    question_type = raw.get("question_type")
+    if not question_type:
+        logger.warning(
+            "golden_sync.skip_missing_field",
+            entry_id=entry_id,
+            missing="question_type",
+        )
+        return None
+
+    is_obd = _is_obd_question_type(question_type)
+    lane = "obd" if is_obd else "manual"
+
     required = (
-        "category", "question_type",
-        "difficulty", "question", "golden_summary",
-        "golden_citations",
+        "category",
+        "difficulty",
+        "question",
+        "golden_summary",
     )
+    if not is_obd:
+        # Manual lane: golden_citations is part of the schema
+        # contract.  Adversarial-manual entries may have an
+        # empty list, but the field must be present.
+        required = required + ("golden_citations",)
     for field in required:
         if field not in raw:
             logger.warning(
@@ -192,10 +213,6 @@ def _extract_entry_fields(
                 missing=field,
             )
             return None
-
-    question_type = raw["question_type"]
-    is_obd = _is_obd_question_type(question_type)
-    lane = "obd" if is_obd else "manual"
 
     # manual_id derivation differs by lane:
     # - Manual: nested inside ``golden_citations[0].manual_id``
@@ -233,7 +250,9 @@ def _extract_entry_fields(
         "obd_context": raw.get("obd_context"),
         "golden_summary_en": raw["golden_summary"],
         "golden_summary_zh": raw.get("golden_summary_zh"),
-        "golden_citations": raw["golden_citations"],
+        # OBD entries don't ship a golden_citations field; default
+        # to empty list to satisfy the NOT NULL JSONB column.
+        "golden_citations": raw.get("golden_citations", []),
         "expected_recall_slugs": raw.get(
             "expected_recall_slugs", [],
         ),

--- a/diagnostic_api/tests/test_golden_sync.py
+++ b/diagnostic_api/tests/test_golden_sync.py
@@ -113,7 +113,13 @@ def test_extract_entry_fields_skips_missing_required_field() -> None:
 
 
 def _obd_entry(entry_id: str) -> Dict[str, object]:
-    """Minimal valid OBD-lane entry dict for the extractor."""
+    """Minimal valid OBD-lane entry dict for the extractor.
+
+    Deliberately omits ``golden_citations`` to match the real
+    PR [2a/4] JSONL shape — OBD entries don't carry manual-side
+    slug citations, and ``golden_sync`` defaults the field to
+    ``[]`` for OBD lanes (it remains required for manual lanes).
+    """
     return {
         "id": entry_id,
         "category": "component",
@@ -121,7 +127,6 @@ def _obd_entry(entry_id: str) -> Dict[str, object]:
         "difficulty": "easy",
         "question": "Peak RPM?",
         "golden_summary": "Peak RPM was 3906.",
-        "golden_citations": [],  # empty for OBD
         "must_contain": ["RPM"],
         "expected_signal_citations": [
             {
@@ -239,6 +244,39 @@ def test_extract_entry_fields_manual_lane_unchanged() -> None:
     # Manual extraction unchanged.
     assert fields["manual_id"] == "MWS150A"
     assert fields["golden_citations"] == raw["golden_citations"]
+
+
+def test_extract_entry_fields_obd_omits_golden_citations_ok() -> None:
+    """OBD entry without ``golden_citations`` should NOT be skipped.
+
+    Regression test for the deploy hotfix: the production OBD
+    JSONL doesn't carry ``golden_citations`` (the field is
+    manual-lane-specific), but the original required-fields
+    check insisted on it being present and skipped all 15
+    entries on the first deploy of [2b/4].  golden_sync now
+    treats ``golden_citations`` as optional for OBD entries and
+    defaults to ``[]`` in the persisted row.
+    """
+    raw = _obd_entry("yamaha-noref-001")
+    assert "golden_citations" not in raw  # sanity
+    fields = _extract_entry_fields(
+        raw, source_path="yamaha_road_test.jsonl", line_number=1,
+    )
+    assert fields is not None
+    assert fields["lane"] == "obd"
+    assert fields["golden_citations"] == []
+
+
+def test_extract_entry_fields_manual_still_requires_golden_citations() -> None:
+    """Manual entries without ``golden_citations`` are still
+    skipped — the schema contract is unchanged for manual lane.
+    """
+    raw = _candidate_entry("manual-noref-001")
+    raw.pop("golden_citations")
+    fields = _extract_entry_fields(
+        raw, source_path="golden/v2/mws150a.jsonl", line_number=1,
+    )
+    assert fields is None
 
 
 def test_extract_entry_fields_obd_lane_dtc_decode() -> None:


### PR DESCRIPTION
Third post-merge hotfix for PR [2b/4]. golden_sync skipped all 15 OBD entries on first deploy because the OBD JSONL doesn't carry golden_citations (manual-lane-specific). Fix: branch by question_type, only require golden_citations for manual entries; default to [] for OBD. 2 new regression tests. 21 sync tests green.