### PR TITLE
docs: biweekly update report 2026-06-09

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # Ensure SQL scripts use LF line endings
 *.sql text eol=lf
+
+# Treat PDFs and other binaries as binary (no line-ending conversion)
+*.pdf binary

--- a/docs/reports/2026-06-09-biweekly.md
+++ b/docs/reports/2026-06-09-biweekly.md
@@ -1,0 +1,58 @@
+# Biweekly Update — STF AI Diagnosis Platform
+
+*Period: 26 May – 9 June 2026*
+
+> **Note:** A light period by design — I was heavily occupied with work and
+> personal commitments, so **no milestone-level progress** was planned or made.
+> Activity was **maintenance and collaborator-driven**: keeping the platform
+> healthy and unblocking the team while real vehicle data started flowing in.
+
+## What happened (incremental, not milestones)
+
+**1. Agent diagnosis now streams live**
+https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/123
+
+The "Agent AI" tab no longer shows a frozen spinner — reasoning, investigation
+steps, and the final diagnosis now stream in real time. A UX fix, shipped and
+live.
+
+**2. First real OBD log from Deng Xiao — parsed; timestamp bug caught & fixed**
+https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/119
+
+Deng Xiao's first real Yamaha road-test log surfaced a data-quality bug (a
+corrupt end-of-file record made a 27-minute trip read as ~12 days). Fixed so
+corrupt rows are safely skipped. Clean session now ready for the golden set.
+
+**3. 15 OBD goldens reviewed by Deng Xiao**
+https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/120
+
+Deng Xiao completed expert scoring and comments on all 15 OBD-agent golden
+answers; more teammate reviews to follow. This is the input the evaluation work
+has been waiting on.
+
+## Next: resuming real progress — 3 priorities
+
+With the data and expert-reviewed goldens now in place, the focus shifts to the
+evaluation & tuning track:
+
+1. **OBD agent eval + tune — HARNESS-25**
+   https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/117
+   Score the OBD agent against Deng Xiao's reviewed Yamaha goldens; iterate to
+   improve.
+
+2. **Full pipeline tuning — HARNESS-24**
+   https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/116
+   Tune prompt + eval + regression across the end-to-end agent.
+
+3. **First baseline eval — HARNESS-23**
+   https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/107
+   Establish the first quality baseline: manual agent vs RAG on 30 locked
+   goldens.
+
+**Suggested sequence:** #107 first — the baseline (manual agent vs RAG) is the
+yardstick everything else tunes against, so it precedes the tuning iterations in
+#117 / #116.
+
+---
+
+*Generated 2026-06-09.*

--- a/docs/reports/2026-06-09-biweekly.pdf
+++ b/docs/reports/2026-06-09-biweekly.pdf
@@ -1,0 +1,128 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/123)
+>> /Border [ 0 0 0 ] /Rect [ 68.3622 592.0719 338.4882 604.0719 ] /Subtype /Link /Type /Annot
+>>
+endobj
+6 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/119)
+>> /Border [ 0 0 0 ] /Rect [ 68.3622 522.0719 338.4882 534.0719 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/120)
+>> /Border [ 0 0 0 ] /Rect [ 68.3622 437.0719 338.4882 449.0719 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/117)
+>> /Border [ 0 0 0 ] /Rect [ 68.3622 295.0719 338.4882 307.0719 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/116)
+>> /Border [ 0 0 0 ] /Rect [ 68.3622 240.0719 338.4882 252.0719 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://github.com/qmohsu/stf_ai_diagnosis_platform_v1/issues/107)
+>> /Border [ 0 0 0 ] /Rect [ 68.3622 185.0719 338.4882 197.0719 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R ] /Contents 15 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/PageMode /UseNone /Pages 14 0 R /Type /Catalog
+>>
+endobj
+13 0 obj
+<<
+/Author (Li-Ta Hsu) /CreationDate (D:20260609031831-07'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260609031831-07'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Biweekly Update \204 STF AI Diagnosis Platform) /Trapped /False
+>>
+endobj
+14 0 obj
+<<
+/Count 1 /Kids [ 11 0 R ] /Type /Pages
+>>
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2137
+>>
+stream
+Gb!#\gN)%,&:O:SlngMtP#sR0([&nS/kmZedo`$61S2]R,U=Q\$(:jjW"8k#mXc&tbHg4jIdm-,.tE9.F3ZDrJ;ldRq4ErQ01KpQg&]6Jd0(HHnmV/3?B#FI%\2W>_q=NHf7bUY/LLi<*/:(hNf>\3fR@Y6#<8R/YCcA2\:P)`67]Pebs-Frk+&%[$i!t>9QN17h$?bGYMnOo]G,0c8L5'u/=<$MVL/H?mkB&[Yl;M3*RMH0':P!.m2.D3O6dti/%>eP'm/@rE,9i\!=0+HO1Z&[3sIWs5M1S7Koj*^[c66!DKn;cc\eGBn/r.6%6tc$,`G+GU6W6FO0M/&'on)TnAE>)S1oI:^1]K"SfZNr[LTF]NGY?!=#,t)e1Io0XVgu'G3,+I^$e:+-Fc6L0_cbJ5;q8"00"Iq.)[so:n)F>GQA[`@Tmp=H4+ek+QmPf0Te+bgKO(Tk!J5bQd%Op.\i\0<iggNQDMqSYI$=n-!)6p_])Pf8l9Q(A]9E.TCE!J7SXo*e.lN$Ea>oL_?FKQ--Ne%-`Ik;Tblk?jcFrbP)2g&MH))Q@&rr*W@SB7Q4;<K).nkqnS3EY@lWYa(=a+@c=pEK9%nQao7bk0>E'#YT!,l'3@eO0j)-QI\G7#g7>`a[l`=GrC"?t95:PZ`#)^RW6*,;*p\b*f@n3d7<k+s6m<aj0_5B3s*m>([Ca_A7'l[nWmh,tJn.$B1H4>4UM4kO'Q^hd2=^?*k_V%1RBu;C9X>kl*l?,#8fos)^%W1[4gr7s.YCg)I+qVhA/#hSLPf@6u$;!D@Hgq5qI0gERgC:shll_<oYi<r3Y)*iaZ^:#$f=G#'7n6KW7Q\%T#tGf.bZ0"co]-r)hg1[I<oj*8F,koO/QYH&lg4orga0'tZ8+[XgAj`7ia986T"P"*1`Kp-Todfh2kY1O=284laFAF<$DgVYgVsp]_Ph[So-*[ML?TLQVM2s,BjRS*8M$g%?3Cp-k--@335-&e(+"eV5(A9CpjqRi$fkQ)VP7&X;U&6e]M39L-'5HV8nXbp\e_poNRAiU5@;(AW(\WS-+r<;iidsU/eg0Y'[N?ir2B:oL2f;/PdP&$O(g70gCN+g-o?%/]jUf[]o0Mtf?nPN>BXQ3#ps?rK0Hr_.L]XUK"kI1EX%M6fhc1O9g2P29NXn40qLJ>BN[WdJMM1&?s&DWVQD`F.N?OPE7-a(^>!;=2JZ3!_)^:a=Gj,t7R]81VKHlj"oi%B1U]Pq,>qo1Z*<n"2b#&pd1r-i/<K/Pd+3g+$I2HY=Op:b]b$"p2"(K"n>;"8AW`+f\DGPNhiI6N4["^p&[OP%$?=;nT6&H^oNBh-aU9-qF^9>Y=Sj`#]tm"dAq4R\JlAN/5Hl0VTTC?snB&JE/Y\gBcluUi/0dAi`d3s[@$R0j)tb1CfrUa.HAn#5k:Sh'Zpa0nfM#C$b0`iOQY7YE]%,p\T<Y-Xgt;733Dt+GEIg+`RK1I#*Q[>-H$@a4c48h9s.PJc^M6DFhT0umnoZ#=iG4"ldXnOud(Jj/RpRIVjn.k\h;n69W0O4#Ob]<GFVu1mJljITe;Nu,ad;Qc1Lq]Y<`,ufBTnme"?ZnE;OLdfZXN+onLaIEXp7$Q[t!h-[adj0$ZoW!m-os102HAuT7$M)lL]2^#(&YJM>'9*^kqc;NInc1n6.%r7C@3#rcKpJ'MfrUW]!LRc`(JA>>jcI#gF=:3Kcpt.$*,)4Ds*4)\&b+C!iAa;=d+^qE*hWZ,#7Xabq5J$Z7r?YJ>&K>sHMa&a9L`=(5h3CaGs5)lk2J?tgicB@t^tBK="dN\1.7NEGVTqKMo*R&M^o#41G^mluponO&GO]jL>*Ge]DkL$elL&?76%?*Dt+TZaP\6cgg*Ds7N`"eSQH:`&'C5Z\9Xic9tTD]Je#IX^P2Iq)o/DcIWMgZ]DVD/+=k7E_b(dcF=bIK5E_p<282qG8kl<h0\Cm/QFoWbYbA-H!`2HJTH/53'mSkN"b<:r\4!=ue$;.A9V5_Dl`;]UNEq;k8E4a:sp'7p#lOL`XE;"P*ls%]n\n_4!>,bfu-,'eaK>@P;]joO>eXHCo(j<];mb&6hGN%(H-2R]Fmb2U*9Js6j,I>[;(k)jG`f.oSklF+H?YnMf.X590S+&\lI!~>endstream
+endobj
+xref
+0 16
+0000000000 65535 f 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000446 00000 n 
+0000000662 00000 n 
+0000000878 00000 n 
+0000001094 00000 n 
+0000001310 00000 n 
+0000001526 00000 n 
+0000001743 00000 n 
+0000001998 00000 n 
+0000002068 00000 n 
+0000002378 00000 n 
+0000002439 00000 n 
+trailer
+<<
+/ID 
+[<cf1b5cdfa1fd784eac71e4580889826e><cf1b5cdfa1fd784eac71e4580889826e>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 13 0 R
+/Root 12 0 R
+/Size 16
+>>
+startxref
+4668
+%%EOF


### PR DESCRIPTION
Adds the 2026-06-09 biweekly update under `docs/reports/` (markdown + PDF).

- Honest framing: a maintenance/collaborator-driven period, no milestone-level progress.
- Highlights: agent streaming (#123), Yamaha log + timestamp fix (#119), 15 OBD goldens reviewed by Deng Xiao (#120).
- Next 3 priorities: HARNESS-25 (#117), HARNESS-24 (#116), HARNESS-23 (#107).
- PDF renders **full GitHub URLs as visible links**. `.gitattributes` updated to treat `*.pdf` as binary.

Docs only — no code or behavior change.