### PR TITLE
test(harness): fix feedback-history test mocks for 6th feedback table (HARNESS-24 follow-up)

### DIFF
--- a/diagnostic_api/tests/test_audio_feedback.py
+++ b/diagnostic_api/tests/test_audio_feedback.py
@@ -369,8 +369,9 @@ class TestDBModelAudioColumns:
         assert "audio_size_bytes" in cols
 
     def test_all_feedback_tables_have_audio(self):
-        """All 5 feedback tables inherit audio columns."""
+        """All 6 feedback tables inherit audio columns."""
         from app.models_db import (
+            OBDAgentDiagnosisFeedback,
             OBDAIDiagnosisFeedback,
             OBDDetailedFeedback,
             OBDPremiumDiagnosisFeedback,
@@ -384,6 +385,7 @@ class TestDBModelAudioColumns:
             OBDRAGFeedback,
             OBDAIDiagnosisFeedback,
             OBDPremiumDiagnosisFeedback,
+            OBDAgentDiagnosisFeedback,
         ):
             cols = {
                 c.name for c in model.__table__.columns

--- a/diagnostic_api/tests/test_obd_analysis.py
+++ b/diagnostic_api/tests/test_obd_analysis.py
@@ -1269,11 +1269,11 @@ def _mock_feedback_db(
 ):
     """Build a mock db for the feedback history endpoint.
 
-    The endpoint issues 1 exists query + 5 feedback table
-    queries.  ``table_rows`` is a list of 5 lists, one per
+    The endpoint issues 1 exists query + 6 feedback table
+    queries.  ``table_rows`` is a list of 6 lists, one per
     feedback table (summary, detailed, rag, ai_diagnosis,
-    premium_diagnosis).  Each inner list contains mock row
-    objects.
+    premium_diagnosis, agent_diagnosis).  Each inner list
+    contains mock row objects.
     """
     mock_db = MagicMock()
 
@@ -1286,7 +1286,7 @@ def _mock_feedback_db(
             .first.return_value = None
 
     if table_rows is None:
-        table_rows = [[] for _ in range(5)]
+        table_rows = [[] for _ in range(6)]
 
     feedback_chains = []
     for rows in table_rows:
@@ -1366,7 +1366,7 @@ class TestFeedbackHistory:
         # Put the row in the first table (summary)
         mock_db = _mock_feedback_db(
             session_exists=True,
-            table_rows=[[row], [], [], [], []],
+            table_rows=[[row], [], [], [], [], []],
         )
 
         from app.api.deps import get_db
@@ -1415,7 +1415,7 @@ class TestFeedbackHistory:
         # merge ordering.
         mock_db = _mock_feedback_db(
             session_exists=True,
-            table_rows=[[older], [newer], [], [], []],
+            table_rows=[[older], [newer], [], [], [], []],
         )
 
         from app.api.deps import get_db
@@ -1473,7 +1473,7 @@ class TestFeedbackHistory:
 
         mock_db = _mock_feedback_db(
             session_exists=True,
-            table_rows=[rows, [], [], [], []],
+            table_rows=[rows, [], [], [], [], []],
         )
 
         from app.api.deps import get_db


### PR DESCRIPTION
## Summary
Follow-up to #133 (HARNESS-24). That PR added `obd_agent_diagnosis_feedback` to `_FEEDBACK_TABLES`, so `get_feedback_history` now issues **6** table queries. The pre-existing `TestFeedbackHistory` tests mocked `db.query.side_effect` with exactly **5** feedback chains, so the 6th query raised `StopIteration` → `RuntimeError: coroutine raised StopIteration` → **5 tests 500'd**.

The original PR added new tests but didn't update these pre-existing mocks. With **no CI** in the repo and the offline tiktoken import block on `app.main`, the regression surfaced only when I ran the suite **inside the prod container** during a post-merge audit.

## Fix (test-only)
- `_mock_feedback_db`: default 5 → 6 empty table-row lists; docstring updated.
- The 3 explicit `table_rows` lists grow 5 → 6 sublists.
- `test_all_feedback_tables_have_audio`: now includes `OBDAgentDiagnosisFeedback` (covers the new table's mixin audio columns).

## Verification
`83 passed` in the prod container: `test_obd_analysis.py` + `test_feedback_diagnosis_link.py` + `test_audio_feedback.py`.

No runtime or doc change (the docs already document the 6th table). No deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)