### PR TITLE
test(obd): fix APP-60 dedup test mock (set make/model)

### DIFF
--- a/diagnostic_api/tests/test_session_isolation.py
+++ b/diagnostic_api/tests/test_session_isolation.py
@@ -201,6 +201,11 @@ class TestPerUserDedup:
             "clue_details": [],
         }
         existing_row.parsed_summary_payload = {"parse_ok": "YES"}
+        # APP-60: the dedup return surfaces the stored vehicle identity,
+        # so the mock row must carry real (non-MagicMock) values.
+        existing_row.manufacturer = "Toyota"
+        existing_row.vehicle_model = "Hiace"
+        existing_row.canonical_name = "Toyota Hiace"
         existing_row.diagnosis_text = None
         existing_row.premium_diagnosis_text = None
         mock_db.query.return_value.filter.return_value \


### PR DESCRIPTION
Follow-up to #138 (APP-60). The dedup-return path now surfaces the stored vehicle identity (`manufacturer` / `vehicle_model` / `canonical_name`). The dedup unit test's `MagicMock` `existing_row` left those as auto-MagicMocks, which `OBDAnalysisResponse` (Optional[str]) rejects — so `test_same_user_same_file_returns_existing` failed.

**Test-only fix** — production reads real nullable columns off the session row; only the mock was incomplete. Set real values on the mock.

Found because the repo has **no CI** and the full TestClient suite can't run in the offline harness (known tiktoken import block). Verified by running the suite **inside the diagnostic-api container** (tiktoken available): `test_session_isolation.py` 7 passed; the full analyze/auth/isolation set is now green (was 88 passed / 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)