### PR TITLE
APP-62: exact-scan fallback for vehicle_model-filtered retrieval (#156)

### DIFF
--- a/diagnostic_api/app/rag/retrieve.py
+++ b/diagnostic_api/app/rag/retrieve.py
@@ -18,7 +18,14 @@ similarity score is meaningful.  Final ``score`` on the returned
 comparable across queries in hybrid mode (relative order within a
 single query is what matters).
 
-APP-56 / Issue #18.
+Filtered queries bypass the HNSW index (APP-62 / Issue #156): when a
+hard ``vehicle_model`` filter is set, the planner is forced to an
+exact sequential scan for the current transaction only — HNSW picks
+approximate nearest neighbours FIRST and filters AFTER, which starves
+a single-manual filter to zero rows once a second, larger manual
+shares the index.  See ``_force_exact_scan_for_filter``.
+
+APP-56 / Issue #18.  APP-62 / Issue #156.
 """
 
 import asyncio
@@ -30,6 +37,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel
 from sqlalchemy import text as sa_text
+from sqlalchemy.orm import Session
 
 from app.db.session import SessionLocal
 from app.models_db import RagChunk
@@ -94,6 +102,46 @@ def _row_to_result(
     )
 
 
+def _force_exact_scan_for_filter(
+    db: Session,
+    vehicle_model: Optional[str],
+) -> str:
+    """Pick the scan path for this transaction; force exact if filtered.
+
+    HNSW on pgvector 0.7.4 (no iterative scan) selects the approximate
+    nearest neighbours FIRST and applies the ``WHERE`` clause AFTER.
+    With >=2 manuals sharing the index, a hard ``vehicle_model``
+    filter starves to 0 rows when the other manual dominates the
+    candidate pool — proven at the pgvector maximum
+    ``hnsw.ef_search=1000`` with TRICITY155 (1665 chunks) vs
+    Corolla E11 (3051 chunks) returning zero TRICITY155 rows
+    (HARNESS-23 / Issue #156).
+
+    ``SET LOCAL`` scopes the planner override to the current
+    transaction only, so unfiltered queries on other connections keep
+    the HNSW speedup.  The exact scan returns the same cosine scores
+    in true order (HNSW is only an approximate-NN speedup) and is
+    cheap at this corpus scale (~5k chunks total, <=3051 per manual,
+    sub-100 ms) — mirrors the eval adapter
+    ``tests/harness/evals/rag_runner._sync_exact_vector_query``,
+    which proved the exact path correct.
+
+    Args:
+        db: Open session; the override binds to its current
+            transaction.
+        vehicle_model: The hard vehicle-model filter, or ``None``.
+
+    Returns:
+        ``"exact"`` if index scans were disabled for the transaction,
+        ``"hnsw"`` otherwise.
+    """
+    if not vehicle_model:
+        return "hnsw"
+    db.execute(sa_text("SET LOCAL enable_indexscan = off"))
+    db.execute(sa_text("SET LOCAL enable_bitmapscan = off"))
+    return "exact"
+
+
 def _sync_vector_query(
     vector: list,
     top_k: int,
@@ -101,6 +149,10 @@ def _sync_vector_query(
     exclude_chunk_ids: Optional[List[int]] = None,
 ) -> List[RetrievalResult]:
     """Pure cosine-similarity query (legacy behaviour).
+
+    When ``vehicle_model`` is set, the query runs as an exact
+    sequential scan instead of HNSW (see
+    ``_force_exact_scan_for_filter`` for why).
 
     Args:
         vector: Query embedding (768-dim float list).
@@ -114,6 +166,13 @@ def _sync_vector_query(
     """
     db = SessionLocal()
     try:
+        scan_path = _force_exact_scan_for_filter(db, vehicle_model)
+        logger.info(
+            "rag_retrieval mode=vector scan_path=%s "
+            "vehicle_model=%s top_k=%d",
+            scan_path, vehicle_model, top_k,
+        )
+
         distance_col = RagChunk.embedding.cosine_distance(
             vector,
         ).label("distance")
@@ -311,6 +370,11 @@ def _sync_hybrid_query(
     ``alpha * vec + (1 - alpha) * kw``.  ``alpha=1`` collapses to
     pure vector; ``alpha=0`` collapses to pure keyword.
 
+    When ``vehicle_model`` is set, the statement runs as an exact
+    sequential scan — the semantic CTE otherwise hits the same
+    HNSW filter starvation as the pure-vector path (see
+    ``_force_exact_scan_for_filter``).
+
     Args:
         vector: Query embedding.
         query_str: User query text.
@@ -405,6 +469,13 @@ def _sync_hybrid_query(
 
     db = SessionLocal()
     try:
+        scan_path = _force_exact_scan_for_filter(db, vehicle_model)
+        logger.info(
+            "rag_retrieval mode=hybrid scan_path=%s "
+            "vehicle_model=%s top_k=%d",
+            scan_path, vehicle_model, top_k,
+        )
+
         rows = db.execute(sql, params).fetchall()
 
         if not rows:

--- a/diagnostic_api/tests/rag/test_retrieve_exact_scan.py
+++ b/diagnostic_api/tests/rag/test_retrieve_exact_scan.py
@@ -1,0 +1,240 @@
+"""Regression tests for filtered-retrieval exact-scan fallback.
+
+APP-62 / Issue #156: with >=2 manuals sharing the HNSW index, a hard
+``vehicle_model`` filter starved production retrieval to 0 rows —
+HNSW selects approximate nearest neighbours FIRST and filters AFTER,
+so the larger manual crowds the filtered one out of the candidate
+pool entirely (proven at the pgvector 0.7.4 maximum
+``hnsw.ef_search=1000``).  The fix forces an exact sequential scan
+(``SET LOCAL enable_indexscan = off``) for the transaction whenever
+the filter is set, while unfiltered queries keep the HNSW path.
+
+No live Postgres in the unit lane, so these tests mock the session
+and assert on the emitted planner overrides:
+
+- filtered vector / hybrid queries emit the ``SET LOCAL`` overrides
+  BEFORE the retrieval statement;
+- unfiltered queries emit no overrides (HNSW path preserved);
+- the path helper labels the choice for structured logging;
+- filtered rows still map to ``RetrievalResult`` (regression shape
+  for "filtered retrieval returns the in-vehicle manual's rows").
+
+The live proof (TRICITY155 filter returns >0 rows with the Corolla
+E11 manual co-ingested) runs on the server post-merge — the eval
+adapter ``rag_runner._sync_exact_vector_query`` already validated
+the identical mechanism against real Postgres (HARNESS-23).
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+from app.rag.retrieve import (
+    _force_exact_scan_for_filter,
+    _sync_hybrid_query,
+    _sync_vector_query,
+)
+
+
+def _mock_session(rows: List[Any] | None = None) -> MagicMock:
+    """Build a chainable mock ``Session`` for both query styles.
+
+    Args:
+        rows: Rows returned by both the ORM ``.all()`` (vector path)
+            and raw-SQL ``.fetchall()`` (hybrid path).
+
+    Returns:
+        MagicMock standing in for ``SessionLocal()``.
+    """
+    rows = rows if rows is not None else []
+    db = MagicMock()
+    orm_query = MagicMock()
+    for chained in ("filter", "order_by", "limit"):
+        getattr(orm_query, chained).return_value = orm_query
+    orm_query.all.return_value = rows
+    db.query.return_value = orm_query
+    db.execute.return_value.fetchall.return_value = rows
+    return db
+
+
+def _set_local_statements(db: MagicMock) -> List[str]:
+    """Extract ``SET LOCAL`` statements emitted on the mock session."""
+    return [
+        str(call.args[0])
+        for call in db.execute.call_args_list
+        if "SET LOCAL" in str(call.args[0])
+    ]
+
+
+def _fake_row(distance: float = 0.2) -> SimpleNamespace:
+    """A row shaped like the vector-path SELECT output."""
+    return SimpleNamespace(
+        text="rear brake torque spec",
+        doc_id="tricity155-manual",
+        source_type="manual",
+        section_title="Rear Brake",
+        chunk_index=7,
+        metadata_json={},
+        distance=distance,
+    )
+
+
+# ── _force_exact_scan_for_filter ──────────────────────────────────
+
+
+def test_force_exact_scan_disables_index_scans_when_filtered():
+    """A hard vehicle_model filter must switch the planner to exact."""
+    db = MagicMock()
+
+    path = _force_exact_scan_for_filter(db, "TRICITY155")
+
+    assert path == "exact"
+    stmts = _set_local_statements(db)
+    assert any("enable_indexscan = off" in s for s in stmts)
+    assert any("enable_bitmapscan = off" in s for s in stmts)
+
+
+def test_force_exact_scan_noop_without_filter():
+    """No filter → HNSW path untouched, no planner overrides."""
+    db = MagicMock()
+
+    path = _force_exact_scan_for_filter(db, None)
+
+    assert path == "hnsw"
+    db.execute.assert_not_called()
+
+
+def test_force_exact_scan_noop_on_empty_string():
+    """Empty-string filter is falsy → treated as unfiltered."""
+    db = MagicMock()
+
+    path = _force_exact_scan_for_filter(db, "")
+
+    assert path == "hnsw"
+    db.execute.assert_not_called()
+
+
+# ── _sync_vector_query scan-path selection ────────────────────────
+
+
+def test_vector_query_filtered_forces_exact_scan():
+    """vehicle_model filter emits SET LOCAL overrides on the txn."""
+    db = _mock_session()
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        _sync_vector_query(
+            [0.1] * 768, 5, vehicle_model="TRICITY155",
+        )
+
+    stmts = _set_local_statements(db)
+    assert any("enable_indexscan = off" in s for s in stmts)
+    assert any("enable_bitmapscan = off" in s for s in stmts)
+
+
+def test_vector_query_unfiltered_keeps_hnsw():
+    """No filter → no planner overrides (HNSW path preserved)."""
+    db = _mock_session()
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        _sync_vector_query([0.1] * 768, 5)
+
+    assert _set_local_statements(db) == []
+
+
+def test_vector_query_exact_scan_set_before_select():
+    """Overrides must land before the retrieval statement runs."""
+    db = _mock_session()
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        _sync_vector_query(
+            [0.1] * 768, 5, vehicle_model="TRICITY155",
+        )
+
+    call_names = [name for name, _args, _kw in db.method_calls]
+    assert "execute" in call_names and "query" in call_names
+    assert call_names.index("execute") < call_names.index("query"), (
+        "SET LOCAL must run before the ORM SELECT in the same txn"
+    )
+
+
+def test_vector_query_filtered_returns_rows():
+    """Regression shape: the filtered query maps rows to results.
+
+    The 0-rows bug meant a filtered query returned nothing at all;
+    with the exact scan the filtered manual's rows come back with
+    cosine similarity scores.
+    """
+    db = _mock_session(rows=[_fake_row(distance=0.2)])
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        results = _sync_vector_query(
+            [0.1] * 768, 5, vehicle_model="TRICITY155",
+        )
+
+    assert len(results) == 1
+    assert results[0].doc_id == "tricity155-manual"
+    assert abs(results[0].score - 0.8) < 1e-9
+
+
+def test_vector_query_logs_scan_path(caplog):
+    """Structured log records which scan path served the query."""
+    db = _mock_session()
+    with caplog.at_level(logging.INFO, logger="app.rag.retrieve"):
+        with patch(
+            "app.rag.retrieve.SessionLocal", return_value=db,
+        ):
+            _sync_vector_query(
+                [0.1] * 768, 5, vehicle_model="TRICITY155",
+            )
+            _sync_vector_query([0.1] * 768, 5)
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("scan_path=exact" in m for m in messages)
+    assert any("scan_path=hnsw" in m for m in messages)
+
+
+# ── _sync_hybrid_query scan-path selection ────────────────────────
+
+
+def test_hybrid_query_filtered_forces_exact_scan():
+    """Hybrid's semantic CTE has the same starvation → same fix."""
+    db = _mock_session()
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        _sync_hybrid_query(
+            [0.1] * 768, "brake torque", 5, 0.5,
+            vehicle_model="TRICITY155",
+        )
+
+    stmts = _set_local_statements(db)
+    assert any("enable_indexscan = off" in s for s in stmts)
+    assert any("enable_bitmapscan = off" in s for s in stmts)
+
+
+def test_hybrid_query_unfiltered_keeps_hnsw():
+    """Unfiltered hybrid keeps the HNSW path (no overrides)."""
+    db = _mock_session()
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        _sync_hybrid_query([0.1] * 768, "brake torque", 5, 0.5)
+
+    assert _set_local_statements(db) == []
+
+
+def test_hybrid_query_exact_scan_set_before_select():
+    """Overrides precede the fused SELECT within the transaction."""
+    db = _mock_session()
+    with patch("app.rag.retrieve.SessionLocal", return_value=db):
+        _sync_hybrid_query(
+            [0.1] * 768, "brake torque", 5, 0.5,
+            vehicle_model="TRICITY155",
+        )
+
+    executed = [str(c.args[0]) for c in db.execute.call_args_list]
+    set_local_idx = [
+        i for i, s in enumerate(executed) if "SET LOCAL" in s
+    ]
+    select_idx = [
+        i for i, s in enumerate(executed) if "semantic" in s
+    ]
+    assert set_local_idx and select_idx
+    assert max(set_local_idx) < min(select_idx), (
+        "SET LOCAL must run before the hybrid SELECT in the same txn"
+    )

--- a/docs/dev_plan.md
+++ b/docs/dev_plan.md
@@ -2020,6 +2020,64 @@ Acceptance Criteria:
 - API startup schedules the pre-warm without blocking `/health` ✓
 - Deploy runbook includes a warm-up step after health checks ✓
 
+#### APP‑62 — Exact-scan fallback for vehicle_model-filtered retrieval
+
+Owner: AI Engineer
+Depends on: APP‑56
+GitHub Issue: #156 (blocks #157)
+
+PROMPT (task ticket):
+Title: APP‑62 Fix filtered-HNSW recall starving to 0 rows with >=2
+manuals (exact-scan fallback)
+
+Task:
+With both the Yamaha TRICITY155 (1665 chunks) and Toyota Corolla E11
+(3051 chunks) manuals ingested, `retrieve_context(vehicle_model=...)`
+returned **0 rows** — even at the pgvector 0.7.4 maximum
+`hnsw.ef_search=1000` — because HNSW selects approximate nearest
+neighbours FIRST and applies the `WHERE vehicle_model = ...` filter
+AFTER, and the larger English manual crowds the filtered manual out
+of the candidate pool entirely (proven during the HARNESS-23 first
+round; the eval worked around it with its own exact-scan adapter
+`tests/harness/evals/rag_runner._sync_exact_vector_query` while
+production retrieval kept the bug).  pgvector 0.7.4 has no
+`hnsw.iterative_scan`, so the smallest correct fix is option (a) of
+issue #156: force an exact sequential scan whenever a hard
+`vehicle_model` filter is present, and keep the HNSW path for
+unfiltered queries.
+
+Key changes:
+- New `_force_exact_scan_for_filter(db, vehicle_model)` in
+  `app/rag/retrieve.py`: when the filter is set, emits `SET LOCAL
+  enable_indexscan = off` + `SET LOCAL enable_bitmapscan = off` —
+  scoped to the current transaction only, so unfiltered queries on
+  other connections keep the HNSW speedup.  Returns
+  `"exact"`/`"hnsw"` for structured logging.  Mirrors the proven
+  eval adapter.  Exact scan is cheap at this corpus scale (~5k
+  chunks total, <=3051 per manual, sub-100 ms) and returns the same
+  cosine scores in true order (HNSW is only an approximate-NN
+  speedup).
+- `_sync_vector_query` and `_sync_hybrid_query` (whose semantic CTE
+  hits the same starvation) call the helper inside their transaction
+  and log `rag_retrieval mode=... scan_path=... vehicle_model=...`.
+- No signature changes; unfiltered callers see byte-identical
+  behaviour.  Keyword mode untouched (GIN index, not affected).
+
+Files changed:
+`diagnostic_api/app/rag/retrieve.py`
+`diagnostic_api/tests/rag/test_retrieve_exact_scan.py` (new — 11 tests)
+
+Acceptance Criteria:
+- Filtered vector + hybrid queries emit the `SET LOCAL` planner
+  overrides before the retrieval statement (unit-asserted) ✓
+- Unfiltered queries emit no overrides — HNSW path preserved ✓
+- Filtered rows map to `RetrievalResult` (regression shape) ✓
+- Structured log records which scan path served each query ✓
+- Live proof (TRICITY155 filter returns >0 rows with the Corolla E11
+  manual co-ingested) — server verification post-merge per the
+  deploy loop; the identical mechanism was already validated against
+  real Postgres by the eval adapter (HARNESS-23)
+
 ### 3.3 Integration and Finalization Tickets
 #### INT‑01 — End-to-end demo script (“one command demo”)
 
@@ -2151,6 +2209,7 @@ If you want, I can also convert these into a ready-to-import backlog format (CSV
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2026-07-12 | vNEXT | APP-62 (HARNESS-23 follow-up T12, GitHub issue #156, blocks #157) — **exact-scan fallback for `vehicle_model`-filtered retrieval**. PRODUCTION BUG: with >=2 manuals sharing the HNSW index (Yamaha TRICITY155, 1665 chunks + Toyota Corolla E11, 3051 chunks), `retrieve_context(vehicle_model=...)` returned **0 rows** even at the pgvector 0.7.4 maximum `hnsw.ef_search=1000` — HNSW selects approximate nearest neighbours FIRST and applies the filter AFTER, so the larger manual crowds the filtered one out of the candidate pool entirely (proven during the HARNESS-23 first round; the eval sidestepped it with its own exact-scan adapter `rag_runner._sync_exact_vector_query` while production kept the bug). pgvector 0.7.4 has no `hnsw.iterative_scan`, so the fix is issue #156 option (a): new `_force_exact_scan_for_filter` in `app/rag/retrieve.py` emits `SET LOCAL enable_indexscan = off` + `enable_bitmapscan = off` (transaction-scoped — unfiltered queries on other connections keep HNSW) whenever a hard `vehicle_model` filter is set; `_sync_vector_query` **and** `_sync_hybrid_query` (its semantic CTE has the same starvation) call it and log `rag_retrieval mode=... scan_path=exact\|hnsw vehicle_model=...`. Exact scan is cheap at this corpus scale (~5k chunks, <=3051 per manual, sub-100 ms) and returns identical cosine scores in true order. No signature changes; unfiltered callers byte-identical; keyword mode untouched (GIN, unaffected). **Tests**: new `tests/rag/test_retrieve_exact_scan.py` (11) — filtered vector/hybrid emit the overrides before the SELECT, unfiltered emit none, helper path labels, scan-path logging, filtered-rows regression shape (29 RAG unit tests green; evals suite 202 passed / 61 skipped). Live proof (TRICITY155 filter returns >0 rows alongside Corolla E11) is the post-merge server verification — no live Postgres in the dev worktree. |
 | 2026-06-21 | v5.15 | APP-61 (follow-up to the HARNESS-23 baseline #107) — **factory-code alias for service manuals**. A manual is referred to by its factory / service-manual code (printed on the cover) as well as its marketing model name: the Yamaha Tricity 155 manual is filed under `vehicle_model=TRICITY155`, but the locked goldens (and the cover) call it `MWS-150-A`. The HARNESS-25 honest agent therefore **refused 27/30** baseline questions ("no manual for MWS-150-A"). **Schema**: new **nullable** `manuals.factory_code VARCHAR(100)`; Alembic `0a1b2c3d4e5f` adds the column and backfills the Yamaha Tricity 155 row to `MWS150-A` (guarded UPDATE, no-op elsewhere). Single head verified. **Ingestion**: `write_frontmatter_identity` gains a `factory_code` param and stamps/clears `factory_code:` in the `.md` frontmatter (kept in sync with the DB row at re-ingestion). **Endpoint**: `POST /v2/manuals/upload` accepts an optional `factory_code` form field (blank → NULL); `ManualSummary` / `ManualDetail` / `ManualUploadResponse` expose it. **Web UI**: `ManualUploadForm` adds an optional **Factory Code** field (no required asterisk, with a one-line hint; i18n en/zh-CN/zh-TW) and passes it to `uploadManual()`; `ManualList` shows the code under the vehicle identity when present; `types.ts` `ManualSummary` / `ManualUploadResponse` gain `factory_code`. **Harness (V2, see v2_dev_plan)**: `list_manuals` renders `factory_code="…"`, matches a vehicle filter against it, and its honest-match footer + `manual_agent_prompts` treat a factory-code match as the SAME vehicle. **Not** denormalised onto `rag_chunks` (vector retrieval filters on canonical `vehicle_model`). **Tests**: 3 `list_manuals` cases (renders, filter-by-code, omitted-when-absent) + 3 `write_frontmatter_identity` cases (writes/omits/clears); updated 2 existing `_to_summary` mocks for the new field (offline, 79 manuals+manual_tools tests green). The §10.3.1 manuals schema + the manual-upload entry point are updated in `design_doc.md` (v5.15). |
 | 2026-06-20 | v5.14 | APP-60 (follow-up to the P00AF Hiace finding #135) — **required vehicle identity on OBD upload**. A vehicle model cannot be derived from an OBD log (verified: the OBDWiz sensor log has 0 mentions of VIN/model; the VIN lives only in the separate Mode-09 report; the pipeline never decodes a VIN to make/model), so the uploader must state it. Without this the agent reverse-reasoned the vehicle from the only same-make manual (called a Hiace a "Corolla"). **Schema**: new `obd_analysis_sessions.manufacturer` + `vehicle_model` (`VARCHAR(100)`) + `OBDAnalysisSession.canonical_name` property; existing `vehicle_id` (VIN/label) kept. Alembic `a7b8c9d0e1f2` adds the two **nullable** columns — required at the API layer (422), DB nullable so the many historical sessions stay valid (no backfill, no NOT NULL). **Endpoint**: `POST /v2/obd/analyze` now requires `manufacturer` + `vehicle_model` query params (422 on blank, whitespace-collapsed); both persisted on the session + stamped into `parsed_summary`; canonical name in `OBDAnalysisResponse`; make/model mismatch on dedup re-upload logs a warning (mirrors APP-54's vehicle_id handling). **Web UI**: `OBDInputForm` adds required Manufacturer + Model fields and gates the Analyze button (i18n en/zh-CN/zh-TW). **Edge agent**: `jetson_uploader` gains `--manufacturer` / `--model` (+ `STF_MANUFACTURER` / `STF_MODEL` env) sent as query params on every upload — the device is installed in one fixed vehicle, configured once; a missing value fails **locally** (rc 1) rather than 422-ing at the server. **Tests**: `test_obd_analysis.py` (missing/blank make/model 422, make/model persisted + in response + parsed_summary), `test_jetson_uploader.py` (query-param send, fail-loud on missing identity), plus updated existing analyze callers across `test_obd_analysis` / `test_auth` / `test_session_isolation`. The agent-context grounding (`Vehicle: <Make> <Model> (VIN …)`) is HARNESS-26 (V2 docs). |
 | 2026-06-19 | v5.13 | APP-59 (GitHub issue #136, follow-up to the P00AF Hiace finding #135) — **required vehicle identity on service manuals**. The first real agent run on a Toyota Hiace (DTC P00AF) mistook the vehicle for a Yamaha scooter because manuals were not reliably tied to a vehicle: `manuals.vehicle_model` was optional + freeform and there was **no manufacturer field**, so the agent's only service-manual content (the Yamaha MWS150-A manual) was treated as authoritative. **Schema**: new `manuals.manufacturer VARCHAR(100)` (required) + `manuals.vehicle_model` promoted to NOT NULL; new `rag_chunks.manufacturer VARCHAR(100)` (nullable, indexed) stamped from the parent manual at ingestion so retrieval can filter by make + model. Alembic `f6a7b8c9d0e1` (down_revision `e4f5a6b7c8d9`) adds the columns, backfills the two manuals in the vault (Yamaha TRICITY155, Toyota Corolla E11) + their chunks, sets a catch-all `'Unknown'` for stray rows, then enforces NOT NULL. **API**: `POST /v2/manuals/upload` now requires `manufacturer` + `vehicle_model` form fields (422 on blank, whitespace-collapsed); responses carry the canonical `"{manufacturer} {vehicle_model}"` name (`Manual.canonical_name` property). **Ingestion**: `embed_and_insert_chunks` stamps make/model from the authoritative `Manual` row; `manual_pipeline.write_frontmatter_identity` writes make/model into the `.md` frontmatter so the harness `list_manuals` tool shows the canonical identity. **Frontend**: `ManualUploadForm` adds a required Manufacturer field, makes Model required, and gates the Upload button (i18n EN / zh-CN / zh-TW); the manual list shows the canonical name. **Tests**: `tests/manuals/test_manuals_api.py` — required-field validation (422), canonical-name property, frontmatter-identity helper (existing + absent frontmatter). The harness honest-matching behaviour is HARNESS-25 (V2 docs). |


### PR DESCRIPTION
## Problem

**Production bug, proven during the HARNESS-23 first round (T12).** With both manuals ingested — Yamaha TRICITY155 (1665 chunks) + Toyota Corolla E11 (3051 chunks) — `retrieve_context(vehicle_model=...)` returned **0 rows**, even at the pgvector 0.7.4 maximum `hnsw.ef_search=1000`. HNSW selects approximate nearest neighbours FIRST and applies the `WHERE vehicle_model = ...` filter AFTER, so the larger English manual crowds the filtered manual out of the candidate pool entirely. The eval worked around this with its own exact-scan adapter (`tests/harness/evals/rag_runner._sync_exact_vector_query`, verified against real Postgres 2026-06-20); production retrieval kept the bug.

## Approach

Issue #156 option (a) — the smallest correct fix. pgvector here is 0.7.4 (no `hnsw.iterative_scan`), and per-manual corpora are small (<=3051 rows, ~5k total), so an exact sequential scan is sub-100 ms and returns the **same cosine scores in true order** (HNSW is only an approximate-NN speedup).

- New `_force_exact_scan_for_filter(db, vehicle_model)` in `diagnostic_api/app/rag/retrieve.py`: when a hard `vehicle_model` filter is set, emits `SET LOCAL enable_indexscan = off` + `SET LOCAL enable_bitmapscan = off`. `SET LOCAL` is transaction-scoped, so unfiltered queries (on this and other connections) keep the HNSW speedup. Mirrors the proven eval adapter exactly.
- Applied in `_sync_vector_query` **and** `_sync_hybrid_query` — the hybrid semantic CTE hits the same starvation. Keyword mode is untouched (GIN index, not affected).
- Structured logging of the path taken: `rag_retrieval mode=vector|hybrid scan_path=exact|hnsw vehicle_model=... top_k=...`.
- No function-signature changes; unfiltered callers see byte-identical behaviour.

## Tests

- New `diagnostic_api/tests/rag/test_retrieve_exact_scan.py` (**11 tests**): filtered vector/hybrid queries emit the planner overrides *before* the retrieval statement; unfiltered queries emit none (HNSW preserved); helper path labels; scan-path logging; filtered-rows-map-to-results regression shape.
- Full RAG unit lane: **29 passed** (`tests/rag/`, includes the 18 pre-existing APP-56 tests).
- Eval suite: **202 passed, 61 skipped** (`tests/harness/evals/`).
- `pytest tests/ -k "retrieve or rag"`: **40 passed, 30 skipped** once the known offline-environment collection errors are excluded (5 harness files + 1 fixture import `app.main`/`app.harness`, whose `harness/context.py` downloads the tiktoken `cl100k_base` encoding at import — fails identically on clean `main` in this offline worktree; unrelated to this change).

## Live-verification caveat

No live Postgres in this dev worktree, so the 0-rows → >0-rows flip is asserted at the SQL/planner level in unit tests only. **Post-merge server verification** (per the CLAUDE.md deploy loop): probe filtered retrieval with both manuals ingested and compare HNSW vs `SET LOCAL enable_indexscan=off` — the identical mechanism was already validated against real Postgres by the eval adapter (HARNESS-23, 2026-06-20).

## Dependencies

- **Blocks #157** (T13: OBD diagnose retrieves with no `vehicle_model` filter — that fix only helps if the filtered path actually returns rows).

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)